### PR TITLE
A subgrid-scale mosaic/tiling approach to land cover in MPAS-Noah

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -36,6 +36,12 @@
                      description="The number of months in a year"/>
                 <dim name="nSoilLevels"        definition="namelist:num_soil_layers"
                      description="The number of soil layers used by the land-surface scheme"/>
+                <dim name="nLandCat"           definition="namelist:num_land_cat"
+                     description="The number of mosaic tiles used by the land-surface scheme"/>
+                <dim name="nMosaicCat"           definition="namelist:config_mosaic_cat"
+                     description="The number of land categories used by the land-surface scheme"/>
+                <dim name="nMosaicCat3D"           definition="nMosaicCat*nSoilLevels"
+                     description="The number of land categories used by the land-surface scheme"/>
                 <dim name="nLags"              definition="namelist:input_soil_temperature_lag"
                      description="The number of days affecting the deep soil temperature"/>
                 <dim name="nOznLevels"         definition="namelist:noznlev"
@@ -447,6 +453,7 @@
 			<var name="surface_pressure"/>
 			<var name="isltyp"/>
 			<var name="ivgtyp"/>
+                        <var name="landusef"/>
 			<var name="mminlu"/>
 			<var name="landmask"/>
 			<var name="shdmin"/>
@@ -762,7 +769,8 @@
 			<var name="ozmixm"/>
 			<var name="isltyp"/>
 			<var name="ivgtyp"/>
-			<var name="mminlu"/>
+                        <var name="landusef"/>
+                        <var name="mminlu"/>
 			<var name="landmask"/>
 			<var name="shdmin"/>
 			<var name="shdmax"/>
@@ -802,9 +810,32 @@
 			<var name="h_oml_initial"/>
 			<var name="hu_oml"/>
 			<var name="hv_oml"/>
+                        <!-- Begin Noah LSM Mosaic variables -->
+                        <var name="landusef2"/>
+                        <var name="mosaic_cat_index"/>
+                        <var name="TSK_mosaic"/>
+                        <var name="CANWAT_mosaic"/>
+                        <var name="SNOW_mosaic"/>
+                        <var name="SNOWH_mosaic"/>
+                        <var name="SNOWC_mosaic"/>
+                        <var name="ALBEDO_mosaic"/>
+                        <var name="ALBBCK_mosaic"/>
+                        <var name="EMISS_mosaic"/>
+                        <var name="EMBCK_mosaic"/>
+                        <var name="ZNT_mosaic"/>
+                        <var name="Z0_mosaic"/>
+                        <var name="QSFC_mosaic"/>
+			<var name="HFX_mosaic"/>
+                        <var name="QFX_mosaic"/>
+			<var name="LH_mosaic"/>
+			<var name="GRDFLX_mosaic"/>
+			<var name="SNOTIME_mosaic"/>
+                        <var name="TSLB_mosaic"/>
+			<var name="SMOIS_mosaic"/>
+			<var name="SH2O_mosaic"/>
 		</stream>
-
-		<stream name="output" 
+  
+                <stream name="output" 
                         type="output" 
                         filename_template="history.$Y-$M-$D_$h.$m.$s.nc" 
                         output_interval="6:00:00"
@@ -923,7 +954,38 @@
 			<var name="tslb"/>
 		</stream>
 
-		<stream name="diagnostics" 
+                <stream name="mosaic" 
+                        type="output" 
+                        filename_template="mosaic.$Y-$M-$D_$h.$m.$s.nc" 
+                        output_interval="6:00:00"
+                        runtime_format="separate_file">
+
+                        <var name="landusef"/>
+                        <var name="landusef2"/>
+                        <var name="mosaic_cat_index"/>
+                        <var name="TSK_mosaic"/>
+                        <var name="CANWAT_mosaic"/>
+                        <var name="SNOW_mosaic"/>
+                        <var name="SNOWH_mosaic"/>
+                        <var name="SNOWC_mosaic"/>
+                        <var name="ALBEDO_mosaic"/>
+                        <var name="ALBBCK_mosaic"/>
+                        <var name="EMISS_mosaic"/>
+                        <var name="EMBCK_mosaic"/>
+                        <var name="ZNT_mosaic"/>
+                        <var name="Z0_mosaic"/>
+                        <var name="QSFC_mosaic"/>
+			<var name="HFX_mosaic"/>
+                        <var name="QFX_mosaic"/>
+			<var name="LH_mosaic"/>
+			<var name="GRDFLX_mosaic"/>
+			<var name="SNOTIME_mosaic"/>
+                        <var name="TSLB_mosaic"/>
+			<var name="SMOIS_mosaic"/>
+			<var name="SH2O_mosaic"/>
+		</stream>
+		
+                <stream name="diagnostics" 
                         type="output" 
                         filename_template="diag.$Y-$M-$D_$h.$m.$s.nc" 
                         output_interval="3:00:00"
@@ -1697,6 +1759,11 @@
                      units="-"
                      description="number of soil layers in Noah land surface scheme"
                      possible_values="Positive integers. For Noah LSM, must be set to 4."/>
+               
+                <nml_option name="num_land_cat" type="integer" default_value="40" in_defaults="false"
+                     units="-"
+                     description="number of land categories used in land surface scheme"
+                     possible_values="Positive integer values."/>
 
                 <nml_option name="months" type="integer" default_value="12" in_defaults="false"
                      units="-"
@@ -1726,6 +1793,16 @@
                      units="-"
                      description="logical for configuration of fractional sea-ice"
                      possible_values=".true. for sea-ice between 0 or 1; .false. for sea-ice equal to 0 or 1 (flag)."/>
+
+                <nml_option name="config_surface_mosaic" type="logical" default_value="false" in_defaults="false"
+                     units="-"
+                     description="logical for configuration of noah lsm mosaic"
+                     possible_values=".true. for noah lsm mosaic on; .false. for noah lsm mosaic off (flag)."/>
+              
+                <nml_option name="config_mosaic_cat" type="integer" default_value="3" in_defaults="false"
+                     units="-"
+                     description="integer number of noah mosaic tiles "
+                     possible_values="Positive integers"/>
 
                 <nml_option name="config_sfc_albedo" type="logical" default_value="true" in_defaults="false"
                      units="-"
@@ -1856,6 +1933,11 @@
                      units="-"
                      description="configuration for surface layer-scheme"
                      possible_values="`suite',`sf_monin_obukhov',`sf_mynn',`off'"/>
+
+                <nml_option name="config_landuse_data" type="character" default_value="USGS"
+                     units="-"
+                     description="The land use classification to use"
+                     possible_values="`USGS' or `MODIFIED\_IGBP\_MODIS\_NOAH' or `NLCD40'"/>
 
                 <nml_option name="config_gfconv_closure_deep" type="integer" default_value="0" in_defaults="false"
                      units="-"
@@ -2887,6 +2969,117 @@
 
                 <var name="tslb" type="real" dimensions="nSoilLevels nCells Time" units="K"
                      description="soil layer temperature"/>
+                
+                <var name="landusef" type="real" dimensions="nLandCat nCells" units="unitless"
+                     description="grid cell fractional landuse"/>
+
+                <var name="landusef2" type="real" dimensions="nLandCat nCells" units="unitless"
+                     description="sorted landuse fraction"/>
+
+                <var name="mosaic_cat_index" type="integer" dimensions="nLandCat nCells Time" units="unitless"
+                     description="index of sorted landuse category"/>
+    
+                <var name="TSK_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="K"
+                     description="SKIN/VEGETATION TEMPERATURE"/>
+
+                <var name="CANWAT_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="kg m^{-2}"
+                     description="CANOPY WATER"/>
+
+                <var name="SNOW_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="kg m^{-2}"
+                     description="SNOW WATER EQUIVALENT"/>
+
+                <var name="SNOWH_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="m"
+                     description="PHYSICAL SNOW DEPTH"/>
+
+                <var name="SNOWC_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="unitless"
+                     description="FLAG INDICATING SNOW COVERAGE"/>
+
+                <var name="ALBEDO_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="unitless"
+                     description="albedo"/>
+
+                <var name="ALBBCK_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="unitless"
+                     description="background albedo"/>
+
+                <var name="EMISS_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="unitless"
+                     description="emissivity"/>
+
+                <var name="EMBCK_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="unitless"
+                     description="background emissivity"/>
+
+                <var name="ZNT_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="m"
+                     description="time varying roughness length"/>
+
+                <var name="Z0_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="m"
+                     description="background roughness length"/>
+
+                <var name="QSFC_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="unitless"
+                     description="SPECIFIC HUMIDITY AT LOWER BOUNDARY"/>
+
+                <var name="HFX_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="unitless"
+                     description="UPWARD HEAT FLUX AT THE SURFACE"/>
+
+                <var name="QFX_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="kg/m2/s"
+                     description="UPWARD MOISTURE FLUX AT THE SURFACE"/>
+
+                <var name="LH_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="W/m2"
+                     description="LATENT HEAT FLUX AT THE SURFACE"/>
+
+                <var name="GRDFLX_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="W/m2"
+                     description="GROUND HEAT FLUX"/>
+
+                <var name="SNOTIME_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="unitless"
+                     description="initial number of time-steps since last snow fall"/>
+
+                <var name="TR_URB2D_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="K"
+                     description="ROOF TEMPERATURE"/>
+
+                <var name="TB_URB2D_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="K"
+                     description="WALL TEMPERATURE"/>
+
+                <var name="TG_URB2D_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="K"
+                     description="GROUND TEMPERATURE"/>
+
+                <var name="TC_URB2D_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="K"
+                     description="CANYON TEMPERATURE"/>
+
+                <var name="QC_URB2D_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="kg/kg"
+                     description="CANYON SPECIFIC HUMIDITY"/>
+
+                <var name="SH_URB2D_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="W/m2"
+                     description="UPWARD HEAT FLUX AT THE SURFACE"/>
+
+                <var name="LH_URB2D_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="kg/m2/s"
+                     description="LATENT HEAT FLUX AT THE SURFACE"/>
+
+                <var name="G_URB2D_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="W/m2"
+                     description="GROUND HEAT FLUX  AT THE SURFACE"/>
+
+                <var name="RN_URB2D_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="W/m2"
+                     description="NET RADIATION"/>
+
+                <var name="TS_URB2D_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="K"
+                     description="URBAN TEMPERATURE"/>
+
+                <var name="TS_RUL2D_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="K"
+                     description="RURAL TEMPERATURE"/>
+
+                <var name="TSLB_mosaic" type="real" dimensions="nMosaicCat nCells Time" units="K"
+                     description="SOIL TEMPERATURE"/>
+
+                <var name="SMOIS_mosaic" type="real" dimensions="nMosaicCat3D nCells Time" units="m3/m3"
+                     description="SOIL MOISTURE"/>
+
+                <var name="SH2O_mosaic" type="real" dimensions="nMosaicCat3D nCells Time" units="m3/m3"
+                     description="SOIL LIQUID WATER"/>
+
+                <var name="TRL_URB3D_mosaic" type="real" dimensions="nMosaicCat3D nCells Time" units="K"
+                     description="ROOF LAYER TEMPERATURE"/>
+
+                <var name="TBL_URB3D_mosaic" type="real" dimensions="nMosaicCat3D nCells Time" units="K"
+                     description="WALL LAYER TEMPERATURE"/>
+
+                <var name="TGL_URB3D_mosaic" type="real" dimensions="nMosaicCat3D nCells Time" units="K"
+                     description="ROAD LAYER TEMPERATURE"/>
 
 
                 <!-- ================================================================================================== -->

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm.F
@@ -82,7 +82,8 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2016-05-11.
 ! * added the calculation of surface variables over seaice cells when config_frac_seaice is set to true.
 !   Laura D. Fowler (laura@ucar.edu) / 2016-10-03.
-
+! * added the allocations and call to use Noah LSM with Mosaic tiling. 
+!   Patrick C. Campbell (campbell.patrickc@epa.gov) / 2017-03-27.
 !
 ! DOCUMENTATION:
 ! ./physics_wrf/module_sf_noahdrv.F: main driver for the "NOAH" land-surface parameterization.
@@ -110,6 +111,9 @@
  if(.not.allocated(smois_p) ) allocate(smois_p(ims:ime,1:num_soils,jms:jme) )
  if(.not.allocated(tslb_p)  ) allocate(tslb_p(ims:ime,1:num_soils,jms:jme)  )
 
+!array for landuse fraction
+ if(.not.allocated(landusef_p)) allocate(landusef_p(ims:ime,1:num_landu,jms:jme))
+ 
 !other arrays:
  if(.not.allocated(acsnom_p)    ) allocate(acsnom_p(ims:ime,jms:jme)    )
  if(.not.allocated(acsnow_p)    ) allocate(acsnow_p(ims:ime,jms:jme)    )
@@ -164,6 +168,31 @@
  if(.not.allocated(th2m_p)      ) allocate(th2m_p(ims:ime,jms:jme)      )
  if(.not.allocated(q2_p)        ) allocate(q2_p(ims:ime,jms:jme)        )
 
+!additional arrays for mosaic lsm
+if(.not.allocated(mosaic_cat_index_p)     ) allocate(mosaic_cat_index_p(ims:ime,1:num_landu,jms:jme)     )  !PCC Mosaic Variables...
+if(.not.allocated(landusef2_p)            ) allocate(landusef2_p(ims:ime,1:num_landu,jms:jme)            )
+if(.not.allocated(TSK_mosaic_p)           ) allocate(TSK_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)      )
+if(.not.allocated(QSFC_mosaic_p)          ) allocate(QSFC_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)     )
+if(.not.allocated(CANWAT_mosaic_p)        ) allocate(CANWAT_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)   ) 
+if(.not.allocated(SNOW_mosaic_p)          ) allocate(SNOW_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)     )
+if(.not.allocated(SNOWH_mosaic_p)         ) allocate(SNOWH_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)    )
+if(.not.allocated(SNOWC_mosaic_p)         ) allocate(SNOWC_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)    )
+if(.not.allocated(ALBEDO_mosaic_p)        ) allocate(ALBEDO_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)   )
+if(.not.allocated(ALBBCK_mosaic_p)        ) allocate(ALBBCK_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)   )
+if(.not.allocated(EMISS_mosaic_p)         ) allocate(EMISS_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)    )
+if(.not.allocated(EMBCK_mosaic_p)         ) allocate(EMBCK_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)    )
+if(.not.allocated(ZNT_mosaic_p)           ) allocate(ZNT_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)      )
+if(.not.allocated(Z0_mosaic_p)            ) allocate(Z0_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)       )
+if(.not.allocated(HFX_mosaic_p)           ) allocate(HFX_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)      )
+if(.not.allocated(QFX_mosaic_p)           ) allocate(QFX_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)      )
+if(.not.allocated(LH_mosaic_p)            ) allocate(LH_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)       )
+if(.not.allocated(GRDFLX_mosaic_p)        ) allocate(GRDFLX_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)   )
+if(.not.allocated(SNOTIME_mosaic_p)       ) allocate(SNOTIME_mosaic_p(ims:ime,1:num_mosaic_cat,jms:jme)  )
+if(.not.allocated(TSLB_mosaic_p)          ) allocate(TSLB_mosaic_p(ims:ime,1:num_mosaic_cat3d,jms:jme)   )
+if(.not.allocated(SMOIS_mosaic_p)         ) allocate(SMOIS_mosaic_p(ims:ime,1:num_mosaic_cat3d,jms:jme)  )
+if(.not.allocated(SH2O_mosaic_p)          ) allocate(SH2O_mosaic_p(ims:ime,1:num_mosaic_cat3d,jms:jme)   )
+
+
  if(config_frac_seaice) then
     if(.not.allocated(tsk_sea)) allocate(tsk_sea(ims:ime,jms:jme))
     if(.not.allocated(tsk_ice)) allocate(tsk_ice(ims:ime,jms:jme))
@@ -184,6 +213,9 @@
  if(allocated(sh2o_p)  ) deallocate(sh2o_p  )
  if(allocated(smois_p) ) deallocate(smois_p )
  if(allocated(tslb_p)  ) deallocate(tslb_p  )
+
+!array for landuse fraction
+ if(allocated(landusef_p)) deallocate(landusef_p)
 
 !other arrays:
  if(allocated(acsnom_p)    ) deallocate(acsnom_p    )
@@ -239,6 +271,32 @@
  if(allocated(th2m_p)      ) deallocate(th2m_p      )
  if(allocated(q2_p)        ) deallocate(q2_p        )
 
+!additional arrays for mosaic lsm
+if(allocated(mosaic_cat_index_p)     ) deallocate(mosaic_cat_index_p)  !PCC Mosaic Variables...
+if(allocated(landusef2_p)            ) deallocate(landusef2_p       )
+if(allocated(TSK_mosaic_p)           ) deallocate(TSK_mosaic_p      )
+if(allocated(QSFC_mosaic_p)          ) deallocate(QSFC_mosaic_p     )
+if(allocated(CANWAT_mosaic_p)        ) deallocate(CANWAT_mosaic_p   ) 
+if(allocated(SNOW_mosaic_p)          ) deallocate(SNOW_mosaic_p     )
+if(allocated(SNOWH_mosaic_p)         ) deallocate(SNOWH_mosaic_p    )
+if(allocated(SNOWC_mosaic_p)         ) deallocate(SNOWC_mosaic_p    )
+if(allocated(ALBEDO_mosaic_p)        ) deallocate(ALBEDO_mosaic_p   )
+if(allocated(ALBBCK_mosaic_p)        ) deallocate(ALBBCK_mosaic_p   )
+if(allocated(EMISS_mosaic_p)         ) deallocate(EMISS_mosaic_p    )
+if(allocated(EMBCK_mosaic_p)         ) deallocate(EMBCK_mosaic_p    )
+if(allocated(ZNT_mosaic_p)           ) deallocate(ZNT_mosaic_p      )
+if(allocated(Z0_mosaic_p)            ) deallocate(Z0_mosaic_p       )
+if(allocated(HFX_mosaic_p)           ) deallocate(HFX_mosaic_p      )
+if(allocated(QFX_mosaic_p)           ) deallocate(QFX_mosaic_p      )
+if(allocated(LH_mosaic_p)            ) deallocate(LH_mosaic_p       )
+if(allocated(GRDFLX_mosaic_p)        ) deallocate(GRDFLX_mosaic_p   )
+if(allocated(SNOTIME_mosaic_p)       ) deallocate(SNOTIME_mosaic_p  )
+if(allocated(TSLB_mosaic_p)          ) deallocate(TSLB_mosaic_p     )
+if(allocated(SMOIS_mosaic_p)         ) deallocate(SMOIS_mosaic_p    )
+if(allocated(SH2O_mosaic_p)          ) deallocate(SH2O_mosaic_p     )
+
+
+
  if(config_frac_seaice) then
     if(allocated(chs_sea) ) deallocate(chs_sea )
     if(allocated(chs2_sea)) deallocate(chs2_sea)
@@ -282,7 +340,14 @@
                                            skintemp,vegfra,xice,xland
  real(kind=RKIND),dimension(:),pointer  :: t2m,th2m,q2
  real(kind=RKIND),dimension(:),pointer  :: raincv,rainncv
- real(kind=RKIND),dimension(:,:),pointer:: sh2o,smcrel,smois,tslb,dzs
+ real(kind=RKIND),dimension(:,:),pointer:: sh2o,smcrel,smois,tslb,dzs,landusef
+
+!Mosaic
+!local pointers
+ integer,dimension(:,:),pointer:: mosaic_cat_index
+ real(kind=RKIND),dimension(:,:),pointer:: landusef2,TSK_mosaic,QSFC_mosaic, CANWAT_mosaic, SNOW_mosaic,SNOWH_mosaic, SNOWC_mosaic, &
+                                            ALBEDO_mosaic,ALBBCK_mosaic, EMISS_mosaic, EMBCK_mosaic, ZNT_mosaic, Z0_mosaic, HFX_mosaic,QFX_mosaic, &
+                                            LH_mosaic,GRDFLX_mosaic,SNOTIME_mosaic,TSLB_mosaic,SMOIS_mosaic,SH2O_mosaic
 
 !local variables and arrays:
  logical:: do_fill
@@ -349,6 +414,31 @@
  call mpas_pool_get_array(sfc_input,'smcrel'       ,smcrel    )
  call mpas_pool_get_array(sfc_input,'smois'        ,smois     )
  call mpas_pool_get_array(sfc_input,'tslb'         ,tslb      )
+ call mpas_pool_get_array(sfc_input,'landusef'     ,landusef  )
+
+ call mpas_pool_get_array(sfc_input,'mosaic_cat_index',mosaic_cat_index)!for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'landusef2',landusef2)!for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'TSK_mosaic' , TSK_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'CANWAT_mosaic' , CANWAT_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SNOW_mosaic' , SNOW_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SNOWH_mosaic' , SNOWH_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SNOWC_mosaic' , SNOWC_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'ALBEDO_mosaic' , ALBEDO_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'ALBBCK_mosaic' , ALBBCK_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'EMISS_mosaic' , EMISS_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'EMBCK_mosaic' , EMBCK_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'ZNT_mosaic' , ZNT_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'Z0_mosaic' , Z0_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'TSLB_mosaic' , TSLB_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SMOIS_mosaic' , SMOIS_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SH2O_mosaic' , SH2O_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'QSFC_mosaic' , QSFC_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'HFX_mosaic' , HFX_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'QFX_mosaic' , QFX_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'LH_mosaic' ,  LH_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'GRDFLX_mosaic' , GRDFLX_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SNOTIME_mosaic' , SNOTIME_mosaic )  !for lsm_mosaic_init (PCC)
+ 
 
 !In Registry.xml, dzs is a function of nCells. In the Noah lsm scheme, dzs is independent
 !of cell locations:
@@ -366,6 +456,53 @@
  enddo
  enddo
  enddo
+
+ do j = jts,jte
+ do n = 1,num_mosaic_cat3d
+ do i = its,ite
+    TSLB_mosaic_p(i,n,j)    = TSLB_mosaic(n,i)    !for lsm_mosaic_init (PCC)
+    SMOIS_mosaic_p(i,n,j)   = SMOIS_mosaic(n,i)   !for lsm_mosaic_init (PCC)
+    SH2O_mosaic_p(i,n,j)    = SH2O_mosaic(n,i)    !for lsm_mosaic_init (PCC)
+ enddo
+ enddo
+ enddo
+
+
+
+ do j = jts,jte
+ do n = 1,num_landu
+ do i = its,ite
+    landusef_p(i,n,j) = landusef(n,i)
+    landusef2_p(i,n,j) = landusef2(n,i)                !for lsm_mosaic_init (PCC)
+    mosaic_cat_index_p(i,n,j) = mosaic_cat_index(n,i)  !for lsm_mosaic_init (PCC)
+ enddo
+ enddo
+ enddo
+
+ do j = jts,jte
+ do n = 1,num_mosaic_cat
+ do i = its,ite
+    TSK_mosaic_p(i,n,j)      = TSK_mosaic(n,i)      !for lsm_mosaic_init (PCC)
+    CANWAT_mosaic_p(i,n,j)   = CANWAT_mosaic(n,i)   !for lsm_mosaic_init (PCC)
+    SNOW_mosaic_p(i,n,j)     = SNOW_mosaic(n,i)     !for lsm_mosaic_init (PCC)
+    SNOWH_mosaic_p(i,n,j)    = SNOWH_mosaic(n,i)    !for lsm_mosaic_init (PCC)
+    SNOWC_mosaic_p(i,n,j)    = SNOWC_mosaic(n,i)    !for lsm_mosaic_init (PCC)
+    ALBEDO_mosaic_p(i,n,j)   = ALBEDO_mosaic(n,i)   !for lsm_mosaic_init (PCC)
+    ALBBCK_mosaic_p(i,n,j)   = ALBBCK_mosaic(n,i)   !for lsm_mosaic_init (PCC)
+    EMISS_mosaic_p(i,n,j)    = EMISS_mosaic(n,i)    !for lsm_mosaic_init (PCC)
+    EMBCK_mosaic_p(i,n,j)   = EMBCK_mosaic(n,i)     !for lsm_mosaic_init (PCC)
+    ZNT_mosaic_p(i,n,j)      = ZNT_mosaic(n,i)      !for lsm_mosaic_init (PCC)
+    Z0_mosaic_p(i,n,j)       = Z0_mosaic(n,i)       !for lsm_mosaic_init (PCC)
+    QSFC_mosaic_p(i,n,j)     = QSFC_mosaic(n,i)     !for lsm_mosaic_init (PCC)
+    HFX_mosaic_p(i,n,j)      = HFX_mosaic(n,i)      !for lsm_mosaic_init (PCC)
+    QFX_mosaic_p(i,n,j)      = QFX_mosaic(n,i)      !for lsm_mosaic_init (PCC)
+    LH_mosaic_p(i,n,j)       = LH_mosaic(n,i)       !for lsm_mosaic_init (PCC)
+    GRDFLX_mosaic_p(i,n,j)   = GRDFLX_mosaic(n,i)   !for lsm_mosaic_init (PCC)
+    SNOTIME_mosaic_p(i,n,j)  = SNOTIME_mosaic(n,i)  !for lsm_mosaic_init (PCC)
+ enddo
+ enddo
+ enddo
+
 
  do j = jts,jte
  do i = its,ite
@@ -511,7 +648,15 @@
                                            skintemp,vegfra,xice,xland
  real(kind=RKIND),dimension(:),pointer  :: t2m,th2m,q2                                           
  real(kind=RKIND),dimension(:),pointer  :: raincv,rainncv
- real(kind=RKIND),dimension(:,:),pointer:: sh2o,smcrel,smois,tslb
+ real(kind=RKIND),dimension(:,:),pointer:: sh2o,smcrel,smois,tslb, landusef
+
+ 
+!Mosaic
+!local pointers
+ integer,dimension(:,:),pointer:: mosaic_cat_index
+ real(kind=RKIND),dimension(:,:),pointer:: landusef2,TSK_mosaic,QSFC_mosaic, CANWAT_mosaic, SNOW_mosaic,SNOWH_mosaic, SNOWC_mosaic, &
+                                            ALBEDO_mosaic,ALBBCK_mosaic, EMISS_mosaic, EMBCK_mosaic, ZNT_mosaic, Z0_mosaic, HFX_mosaic,QFX_mosaic, &
+                                            LH_mosaic,GRDFLX_mosaic,SNOTIME_mosaic,TSLB_mosaic,SMOIS_mosaic,SH2O_mosaic
 
 !local variables and arrays:
  integer:: ip,iEdg
@@ -577,6 +722,32 @@
  call mpas_pool_get_array(sfc_input,'smcrel'       ,smcrel    )
  call mpas_pool_get_array(sfc_input,'smois'        ,smois     )
  call mpas_pool_get_array(sfc_input,'tslb'         ,tslb      )
+ call mpas_pool_get_array(sfc_input,'landusef'     ,landusef  )
+
+
+ call mpas_pool_get_array(sfc_input,'mosaic_cat_index',mosaic_cat_index)!for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'landusef2',landusef2)!for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'TSK_mosaic' , TSK_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'CANWAT_mosaic' , CANWAT_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SNOW_mosaic' , SNOW_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SNOWH_mosaic' , SNOWH_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SNOWC_mosaic' , SNOWC_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'ALBEDO_mosaic' , ALBEDO_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'ALBBCK_mosaic' , ALBBCK_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'EMISS_mosaic' , EMISS_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'EMBCK_mosaic' , EMBCK_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'ZNT_mosaic' , ZNT_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'Z0_mosaic' , Z0_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'TSLB_mosaic' , TSLB_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SMOIS_mosaic' , SMOIS_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SH2O_mosaic' , SH2O_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'QSFC_mosaic' , QSFC_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'HFX_mosaic' , HFX_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'QFX_mosaic' , QFX_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'LH_mosaic' ,  LH_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'GRDFLX_mosaic' , GRDFLX_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SNOTIME_mosaic' , SNOTIME_mosaic )  !for lsm_mosaic_init (PCC)
+ 
 
  do j = jts,jte
  do n = 1,num_soils
@@ -588,6 +759,53 @@
  enddo
  enddo
  enddo
+
+ do j = jts,jte
+ do n = 1,num_mosaic_cat3d
+ do i = its,ite
+    TSLB_mosaic(n,i)  = TSLB_mosaic_p(i,n,j)       !for lsm_mosaic_init (PCC)
+    SMOIS_mosaic(n,i) = SMOIS_mosaic_p(i,n,j)      !for lsm_mosaic_init (PCC)
+    SH2O_mosaic(n,i)  = SH2O_mosaic_p(i,n,j)       !for lsm_mosaic_init (PCC)
+ enddo
+ enddo
+ enddo
+
+
+ do j = jts,jte
+ do n = 1,num_landu
+ do i = its,ite
+    landusef(n,i)         = landusef_p(i,n,j)
+    landusef2(n,i)        = landusef2_p(i,n,j)               !for lsm_mosaic_init (PCC)
+    mosaic_cat_index(n,i) = mosaic_cat_index_p(i,n,j)        !for lsm_mosaic_init (PCC)
+ enddo
+ enddo
+ enddo
+
+
+ do j = jts,jte
+ do n = 1,num_mosaic_cat
+ do i = its,ite
+    TSK_mosaic(n,i)    = TSK_mosaic_p(i,n,j)        !for lsm_mosaic_init (PCC)
+    CANWAT_mosaic(n,i) = CANWAT_mosaic_p(i,n,j)     !for lsm_mosaic_init (PCC)
+    SNOW_mosaic(n,i)   = SNOW_mosaic_p(i,n,j)       !for lsm_mosaic_init (PCC)
+    SNOWH_mosaic(n,i)  = SNOWH_mosaic_p(i,n,j)      !for lsm_mosaic_init (PCC)
+    SNOWC_mosaic(n,i)  = SNOWC_mosaic_p(i,n,j)      !for lsm_mosaic_init (PCC)
+    ALBEDO_mosaic(n,i) = ALBEDO_mosaic_p(i,n,j)     !for lsm_mosaic_init (PCC)
+    ALBBCK_mosaic(n,i) = ALBBCK_mosaic_p(i,n,j)     !for lsm_mosaic_init (PCC)
+    EMISS_mosaic(n,i)  = EMISS_mosaic_p(i,n,j)      !for lsm_mosaic_init (PCC)
+    EMBCK_mosaic(n,i) = EMBCK_mosaic_p(i,n,j)     !for lsm_mosaic_init (PCC)
+    ZNT_mosaic(n,i)    = ZNT_mosaic_p(i,n,j)        !for lsm_mosaic_init (PCC)
+    Z0_mosaic(n,i)     = Z0_mosaic_p(i,n,j)         !for lsm_mosaic_init (PCC)
+    QSFC_mosaic(n,i)   = QSFC_mosaic_p(i,n,j)       !for lsm_mosaic_init (PCC)
+    HFX_mosaic(n,i)    = HFX_mosaic_p(i,n,j)        !for lsm_mosaic_init (PCC)
+    QFX_mosaic(n,i)    = QFX_mosaic_p(i,n,j)        !for lsm_mosaic_init (PCC)
+    LH_mosaic(n,i)     = LH_mosaic_p(i,n,j)         !for lsm_mosaic_init (PCC)
+    GRDFLX_mosaic(n,i) = GRDFLX_mosaic_p(i,n,j)     !for lsm_mosaic_init (PCC)
+    SNOTIME_mosaic(n,i)= SNOTIME_mosaic_p(i,n,j)    !for lsm_mosaic_init (PCC)
+ enddo
+ enddo
+ enddo
+
 
  do j = jts,jte
  do i = its,ite
@@ -669,7 +887,6 @@
     enddo
     enddo
  endif
-
  end subroutine lsm_to_MPAS
  
 !=================================================================================================================
@@ -680,7 +897,7 @@
  type(dm_info),intent(in):: dminfo
  type(mpas_pool_type):: mesh
  type(mpas_pool_type),intent(in):: configs
-
+ 
 !inout arguments:
  type(mpas_pool_type),intent(inout):: diag_physics
  type(mpas_pool_type),intent(inout):: sfc_input
@@ -691,7 +908,7 @@
 
     case ("noah")
        call noah_init_forMPAS(dminfo,mesh,configs,diag_physics,sfc_input)
-    
+       
     case default
  
  end select lsm_select
@@ -708,6 +925,7 @@
 
  integer,intent(in):: its,ite
  integer,intent(in):: itimestep
+ 
 
 !inout arguments:
  type(mpas_pool_type),intent(inout):: diag_physics
@@ -717,13 +935,48 @@
  logical,pointer:: config_sfc_albedo
  character(len=StrKIND),pointer:: mminlu
 
+!Mosaic
+!local pointers
+ logical,pointer::config_surface_mosaic
+ integer,pointer:: config_mosaic_cat
+ integer,dimension(:,:),pointer:: mosaic_cat_index
+ real(kind=RKIND),dimension(:,:),pointer:: landusef2,TSK_mosaic,QSFC_mosaic, CANWAT_mosaic, SNOW_mosaic,SNOWH_mosaic, SNOWC_mosaic, &
+                                            ALBEDO_mosaic,ALBBCK_mosaic, EMISS_mosaic, EMBCK_mosaic, ZNT_mosaic, Z0_mosaic, HFX_mosaic,QFX_mosaic, &
+                                            LH_mosaic,GRDFLX_mosaic,SNOTIME_mosaic,TSLB_mosaic,SMOIS_mosaic,SH2O_mosaic
+!local
+integer:: config_surface_mosaic_yes
+ 
 !-----------------------------------------------------------------------------------------------------------------
 !write(0,*)
 !write(0,*) '--- enter subroutine driver_lsm:'
 
- call mpas_pool_get_config(configs,'config_sfc_albedo' ,config_sfc_albedo )
+ call mpas_pool_get_config(configs,'config_sfc_albedo'     ,config_sfc_albedo    )
+ call mpas_pool_get_config(configs,'config_surface_mosaic' ,config_surface_mosaic)
+ call mpas_pool_get_config(configs,'config_mosaic_cat'     ,config_mosaic_cat)
  call mpas_pool_get_array(sfc_input,'mminlu',mminlu)
-
+ call mpas_pool_get_array(sfc_input,'mosaic_cat_index',mosaic_cat_index)
+ call mpas_pool_get_array(sfc_input,'landusef2',landusef2)
+ call mpas_pool_get_array(sfc_input,'TSK_mosaic' , TSK_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'CANWAT_mosaic' , CANWAT_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SNOW_mosaic' , SNOW_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SNOWH_mosaic' , SNOWH_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SNOWC_mosaic' , SNOWC_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'ALBEDO_mosaic' , ALBEDO_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'ALBBCK_mosaic' , ALBBCK_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'EMISS_mosaic' , EMISS_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'EMBCK_mosaic' , EMBCK_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'ZNT_mosaic' , ZNT_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'Z0_mosaic' , Z0_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'TSLB_mosaic' , TSLB_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SMOIS_mosaic' , SMOIS_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SH2O_mosaic' , SH2O_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'QSFC_mosaic' , QSFC_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'HFX_mosaic' , HFX_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'QFX_mosaic' , QFX_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'LH_mosaic' ,  LH_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'GRDFLX_mosaic' , GRDFLX_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SNOTIME_mosaic' , SNOTIME_mosaic )  !for lsm_mosaic_init (PCC)
+ 
 !formats:
  101 format(2i6,8(1x,e15.8))
  102 format(3i6,8(1x,e15.8))
@@ -736,7 +989,57 @@
  lsm_select: select case (trim(lsm_scheme))
 
     case("noah")
-       call lsm( &
+ if(config_surface_mosaic) then
+config_surface_mosaic_yes = 1
+       call lsm_mosaic( &
+                dz8w      = dz_p      , p8w3d     = pres2_hyd_p  , t3d       = t_p          , &  
+                qv3d      = qv_p      , xland     = xland_p      , xice      = xice_p       , &
+                ivgtyp    = ivgtyp_p  , isltyp    = isltyp_p     , tmn       = tmn_p        , &
+                vegfra    = vegfra_p  , shdmin    = shdmin_p     , shdmax    = shdmax_p     , &
+                snoalb    = snoalb_p  , glw       = glw_p        , gsw       = gsw_p        , &
+                swdown    = swdown_p  , rainbl    = rainbl_p     , embck     = sfc_emibck_p , & 
+                sr        = sr_p      , qgh       = qgh_p        , cpm       = cpm_p        , &
+                qz0       = qz0_p     , tsk       = tsk_p        , hfx       = hfx_p        , & 
+                qfx       = qfx_p     , lh        = lh_p         , grdflx    = grdflx_p     , &
+                qsfc      = qsfc_p    , cqs2      = cqs2_p       , chs       = chs_p        , &
+                chs2      = chs2_p    , snow      = snow_p       , snowc     = snowc_p      , &
+                snowh     = snowh_p   , canwat    = canwat_p     , smstav    = smstav_p     , &
+                smstot    = smstot_p  , sfcrunoff = sfcrunoff_p  , udrunoff  = udrunoff_p   , &               
+                acsnom    = acsnom_p  , acsnow    = acsnow_p     , snotime   = snotime_p    , &
+                snopcx    = snopcx_p  , emiss     = sfc_emiss_p  , rib       = br_p         , &
+                potevp    = potevp_p  , albedo    = sfc_albedo_p , albbck    = sfc_albbck_p , &
+                z0        = z0_p      , znt       = znt_p        , lai       = lai_p        , &
+                noahres   = noahres_p , chklowq   = chklowq_p    , sh2o      = sh2o_p       , &
+                smois     = smois_p   , tslb      = tslb_p       , smcrel    = smcrel_p     , &
+                dzs       = dzs_p     , isurban   = isurban      , isice     = isice        , &                
+                rovcp     = rcp       , dt        = dt_pbl       , myj       = myj          , &
+                itimestep = itimestep , frpcpn    = frpcpn       , rdlai2d   = rdlai2d      , &
+                xice_threshold   = xice_threshold    ,                                        &
+                usemonalb        = config_sfc_albedo ,                                        &
+                mminlu           = mminlu ,                                                   &
+                NLCAT = num_landu,landusef = landusef_p, landusef2 = landusef2_p,                                                                        & ! danli mosaic
+                sf_surface_mosaic = config_surface_mosaic_yes, mosaic_cat = config_mosaic_cat, mosaic_cat_index = mosaic_cat_index_p,  	 & ! danli mosaic 
+                TSK_mosaic = TSK_mosaic_p, QSFC_mosaic = QSFC_mosaic_p,                        	                          			 & ! danli mosaic 
+                TSLB_mosaic = TSLB_mosaic_p, SMOIS_mosaic = SMOIS_mosaic_p, SH2O_mosaic = SH2O_mosaic_p,           	                                 & ! danli mosaic 
+                CANWAT_mosaic = CANWAT_mosaic_p, SNOW_mosaic = SNOW_mosaic_p,                      		                                         & ! danli mosaic
+                SNOWH_mosaic = SNOWH_mosaic_p, SNOWC_mosaic = SNOWC_mosaic_p,                      			                                 & ! danli mosaic 
+                ALBEDO_mosaic = ALBEDO_mosaic_p, ALBBCK_mosaic = ALBBCK_mosaic_p,                    			                         & ! danli mosaic
+                EMISS_mosaic = EMISS_mosaic_p, EMBCK_mosaic = EMBCK_mosaic_p,                     			                                 & ! danli mosaic
+                ZNT_mosaic = ZNT_mosaic_p, Z0_mosaic = Z0_mosaic_p,                          			                                 & ! danli mosaic 
+                HFX_mosaic = HFX_mosaic_p, QFX_mosaic = QFX_mosaic_p,                          			                                 & ! danli mosaic
+                LH_mosaic = LH_mosaic_p, GRDFLX_mosaic = GRDFLX_mosaic_p, SNOTIME_mosaic = SNOTIME_mosaic_p,                                           & ! danli mosaic
+                num_soil_layers  = num_soils    ,                                             &         
+                num_roof_layers  = num_soils    ,                                             &
+                num_wall_layers  = num_soils    ,                                             &
+                num_road_layers  = num_soils    ,                                             &
+                num_urban_layers = num_soils    ,                                             &
+                sf_urban_physics = sf_urban_physics   ,                                       &
+                ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,       &
+                ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,       &
+                its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte         &
+               )
+ elseif(.not.config_surface_mosaic) then
+      call lsm( &
                 dz8w      = dz_p      , p8w3d     = pres2_hyd_p  , t3d       = t_p          , &  
                 qv3d      = qv_p      , xland     = xland_p      , xice      = xice_p       , &
                 ivgtyp    = ivgtyp_p  , isltyp    = isltyp_p     , tmn       = tmn_p        , &
@@ -772,7 +1075,7 @@
                 ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,       &
                 its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte         &
                )
-
+ endif
        call sfcdiags( &
                 hfx   = hfx_p  , qfx     = qfx_p   , tsk  = tsk_p , qsfc = qsfc_p , chs = chs_p , &
                 chs2  = chs2_p , cqs2    = cqs2_p  , t2   = t2m_p , th2  = th2m_p , q2  = q2_p  , &

--- a/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
@@ -49,7 +49,8 @@
 ! * In subroutine physics_init_seaice, assign the sea-ice land use category as a function of
 !   the land use category input file (MODIS OR USGS).
 !   Dominikus Heinzeller (IMK) / 2014-07-24.
-
+!   added case('NLCD40') to use NLCD40 for landusef in Noah Mosaic
+!   Patrick Campbell (campbell.patrickc@epa.gov)  2017-08-03
 
  contains
 
@@ -646,6 +647,8 @@
     case('USGS')
        isice_lu = 24
     case('MODIFIED_IGBP_MODIS_NOAH')
+       isice_lu = 15
+    case('NLCD40')
        isice_lu = 15
     case default
        CALL physics_error_fatal ('Invalid Land Use Dataset '//trim(config_landuse_data))

--- a/src/core_atmosphere/physics/mpas_atmphys_landuse.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_landuse.F
@@ -73,7 +73,8 @@
 ! * in subroutine landuse_int_forMPAS, added the initialization of variable ust to a very small value. this was
 !   needed when the surface layer scheme was updated to that used in WRF version 3.8.1
 !   Laura D. Fowler (laura@ucar.edu) / 2016-10-27.
-
+!   Added case('NLCD40') for Noah Mosaic Option
+!   Patrick Campbell, campbell.patrickc@epa.gov 2017-08-03
 
  contains
 
@@ -226,6 +227,10 @@
           iswater = 2
           isice   = 3
           isurban = 1
+       case('NLCD40')
+          iswater = 17
+          isice   = 15
+          isurban = 22
        case default
     end select sfc_input_select
  endif

--- a/src/core_atmosphere/physics/mpas_atmphys_lsm_noahinit.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_lsm_noahinit.F
@@ -18,10 +18,14 @@
  use mpas_derived_types
  use mpas_pool_routines
 
+
  use mpas_atmphys_constants
  use mpas_atmphys_utilities
+ use mpas_atmphys_landuse, only: isice, iswater
+
 !wrf physics
  use module_sf_noahlsm
+
 
  implicit none
  private
@@ -43,7 +47,8 @@
 !   Laura D. Fowler (laura@ucar.edu) / 2014-03-21.
 ! * added "use mpas_kind_types" at the top of the module.
 !   Laura D. Fowler (laura@ucar.edu) / 2014-09-18.
-
+! * added lsm_mosaic_init subroutine and declarations.
+!   Patrick C. Campbell (campbell.patrickc@epa.gov) / 2017-05-18.
 
  contains
 
@@ -53,8 +58,8 @@
 !=================================================================================================================
 
 !input arguments:
- type(dm_info):: dminfo
- type(mpas_pool_type):: mesh
+ type(dm_info),intent(in):: dminfo
+ type(mpas_pool_type),intent(in):: mesh
  type(mpas_pool_type),intent(in):: configs
 
 !inout arguments:
@@ -64,6 +69,7 @@
 !-----------------------------------------------------------------------------------------------------------------
 
 !read formatted files needed for land-surface model:
+
  call lsminit(dminfo,mesh,configs,diag_physics,sfc_input)
 
  end subroutine noah_init_forMPAS
@@ -84,6 +90,7 @@
 !local pointers::
  logical,pointer:: input_sfc_albedo,restart
 
+
  character(len=StrKIND),pointer:: mminlu,mminsl
 
  integer,pointer:: nCells,nSoilLevels
@@ -92,35 +99,102 @@
  real(kind=RKIND),dimension(:),pointer:: snoalb,snow,snowh
  real(kind=RKIND),dimension(:,:),pointer:: tslb,smois,sh2o
 
+
 !local variables:
  logical,parameter:: fndsnowh = .true.
 
- integer:: iCell
+ integer:: iCell,mosaic_i,NumPairs,lastswap,ice,soil_k,i,temp2,temp5
  integer:: errflag,ns
 
- real(kind=RKIND):: bx,fk,smcmax,psisat,free
+ real(kind=RKIND):: bx,fk,smcmax,psisat,free,xice_threshold,temp,temp4,temp6
  real(kind=RKIND),parameter:: blim = 5.5
  real(kind=RKIND),parameter:: hlice = 3.335e5
  real(kind=RKIND),parameter:: t0 = 273.15
 
+!-------------------------------------------------
+! Noah-mosaic related variables are added to declaration  (danli)
+!-------------------------------------------------
+!local pointers::
+  logical,pointer:: config_surface_mosaic 
+  integer,pointer:: config_mosaic_cat
+  logical,pointer:: config_frac_seaice
+  integer,pointer:: nLandCat
+
+  real(kind=RKIND),dimension(:,:),pointer:: landusef
+  real(kind=RKIND),dimension(:,:,:),pointer:: landusef_p
+  real(kind=RKIND),dimension(:),pointer:: skintemp
+  real(kind=RKIND),dimension(:),pointer:: snowc
+  real(kind=RKIND),dimension(:),pointer:: canwat
+  real(kind=RKIND),dimension(:),pointer:: xland
+  real(kind=RKIND),dimension(:),pointer:: xice
+  real(kind=RKIND),dimension(:,:),pointer:: landusef2,TSK_mosaic, CANWAT_mosaic, SNOW_mosaic,SNOWH_mosaic, SNOWC_mosaic, &
+                                            ALBEDO_mosaic,ALBBCK_mosaic, EMISS_mosaic, EMBCK_mosaic, ZNT_mosaic, Z0_mosaic
+  real(kind=RKIND),dimension(:,:),pointer:: TSLB_mosaic,SMOIS_mosaic,SH2O_mosaic,TRL_URB3D_mosaic, TBL_URB3D_mosaic, TGL_URB3D_mosaic
+
+  real(kind=RKIND),dimension(:,:),pointer:: TR_URB2D_mosaic, TB_URB2D_mosaic,TG_URB2D_mosaic, TC_URB2D_mosaic,QC_URB2D_mosaic, &
+                                            SH_URB2D_mosaic,LH_URB2D_mosaic, G_URB2D_mosaic,RN_URB2D_mosaic,TS_URB2D_mosaic, TS_RUL2D_mosaic
+  integer,dimension(:,:),pointer:: mosaic_cat_index
+      
 !-----------------------------------------------------------------------------------------------------------------
 
- call mpas_pool_get_array(sfc_input,'mminlu'              ,mminlu          )
- call mpas_pool_get_config(configs,'input_soil_data'      ,mminsl          )
- call mpas_pool_get_config(configs,'config_sfc_snowalbedo',input_sfc_albedo)
- call mpas_pool_get_config(configs,'config_do_restart'    ,restart         )
-
+ call mpas_pool_get_array(sfc_input,'mminlu'              ,mminlu                        )
+ call mpas_pool_get_config(configs,'input_soil_data'      ,mminsl                        )
+ call mpas_pool_get_config(configs,'config_sfc_snowalbedo',input_sfc_albedo              )
+ call mpas_pool_get_config(configs,'config_do_restart'    ,restart                       )
+ call mpas_pool_get_config(configs,'config_surface_mosaic',config_surface_mosaic         ) !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_config(configs,'config_mosaic_cat'    ,config_mosaic_cat             ) !for lsm_mosaic_init (PCC)  Number of mosaic tiles
+ call mpas_pool_get_config(configs,'config_frac_seaice'   ,config_frac_seaice            ) !for lsm_mosaic_init (PCC)
  call mpas_pool_get_dimension(mesh,'nCells'     ,nCells     )
  call mpas_pool_get_dimension(mesh,'nSoilLevels',nSoilLevels)
+ call mpas_pool_get_dimension(mesh,'nLandCat',nLandCat)
 
- call mpas_pool_get_array(sfc_input,'isltyp', isltyp)
- call mpas_pool_get_array(sfc_input,'ivgtyp', ivgtyp)
- call mpas_pool_get_array(sfc_input,'sh2o'  , sh2o  )
- call mpas_pool_get_array(sfc_input,'smois' , smois )
- call mpas_pool_get_array(sfc_input,'tslb'  , tslb  )
- call mpas_pool_get_array(sfc_input,'snoalb', snoalb)
- call mpas_pool_get_array(sfc_input,'snow'  , snow  )
- call mpas_pool_get_array(sfc_input,'snowh' , snowh )
+ call mpas_pool_get_array(sfc_input,'isltyp'    , isltyp    )
+ call mpas_pool_get_array(sfc_input,'ivgtyp'    , ivgtyp    )
+ call mpas_pool_get_array(sfc_input,'sh2o'      , sh2o      )
+ call mpas_pool_get_array(sfc_input,'smois'     , smois     )
+ call mpas_pool_get_array(sfc_input,'tslb'      , tslb      )
+ call mpas_pool_get_array(sfc_input,'snoalb'    , snoalb    )
+ call mpas_pool_get_array(sfc_input,'snow'      , snow      )
+ call mpas_pool_get_array(sfc_input,'snowh'     , snowh     )
+ call mpas_pool_get_array(sfc_input,'skintemp'  , skintemp  )  !input...for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'landusef'  , landusef  )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'snowc'     , snowc     )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'xland'     , xland     )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'xice'      , xice      )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(diag_physics,'canwat' , canwat    )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'landusef2' , landusef2 )  !output....for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'TSK_mosaic' , TSK_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'CANWAT_mosaic' , CANWAT_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SNOW_mosaic' , SNOW_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SNOWH_mosaic' , SNOWH_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SNOWC_mosaic' , SNOWC_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'ALBEDO_mosaic' , ALBEDO_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'ALBBCK_mosaic' , ALBBCK_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'EMISS_mosaic' , EMISS_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'EMBCK_mosaic' , EMBCK_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'ZNT_mosaic' , ZNT_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'Z0_mosaic' , Z0_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'TSLB_mosaic' , TSLB_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SMOIS_mosaic' , SMOIS_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SH2O_mosaic' , SH2O_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'TRL_URB3D_mosaic' , TRL_URB3D_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'TBL_URB3D_mosaic' , TBL_URB3D_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'TGL_URB3D_mosaic' , TGL_URB3D_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'TR_URB2D_mosaic' , TR_URB2D_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'TB_URB2D_mosaic' , TB_URB2D_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'TG_URB2D_mosaic' , TG_URB2D_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'TC_URB2D_mosaic' , TC_URB2D_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'QC_URB2D_mosaic' , QC_URB2D_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'SH_URB2D_mosaic' , SH_URB2D_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'LH_URB2D_mosaic' , LH_URB2D_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'G_URB2D_mosaic' , G_URB2D_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'RN_URB2D_mosaic' , RN_URB2D_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'TS_URB2D_mosaic' , TS_URB2D_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'TS_RUL2D_mosaic' , TS_RUL2D_mosaic )  !for lsm_mosaic_init (PCC)
+ call mpas_pool_get_array(sfc_input,'mosaic_cat_index' , mosaic_cat_index )  !for lsm_mosaic_init (PCC)
+
+ 
+ 
 
 !reads the NOAH LSM tables:
  write(0,*)
@@ -135,7 +209,7 @@
     do iCell = 1, nCells
        if(isltyp(iCell) .lt. 1) then
           errflag = 1
-          write(err_message,*) "module_sf_noahlsm.F: lsminit: out of range ISLTYP ", &
+          write(err_message,*) "modunumle_sf_noahlsm.F: lsminit: out of range ISLTYP ", &
                                iCell,isltyp(iCell)
           call physics_message(err_message)
        endif
@@ -198,8 +272,336 @@
     endif
     110 continue
 
- endif
+!    write(*,*), '--- snowh = (Noah LSM initialize)', snowh
+!    write(*,*), '--- sh2o = (Noah LSM initialize)', sh2o
+!    write(*,*), '--- tslb = (Noah LSM initialize)', tslb
+ IF (config_surface_mosaic) THEN   !lsm_mosaic_init (pcc)
 
+! write(*,*),'--- assign NOAH LSM mosaic from tables, config_surface_mosaic = ',  config_surface_mosaic
+! write(*,*),'--- config_frac_seaice= ', config_frac_seaice
+ 
+if(.not. config_frac_seaice) then
+    xice_threshold = 0.5_RKIND
+ elseif(config_frac_seaice) then
+    xice_threshold = 0.02
+ endif
+ !write(0,*) '--- config_frac_seaice      :', config_frac_seaice
+ !write(0,*) '--- xice_threshold          :', xice_threshold
+
+
+  !===========================================================================   
+  ! CHOOSE THE TILES
+  !===========================================================================  
+  
+!  itf=min0(ite,ide-1)
+!  jtf=min0(jte,jde-1)
+
+  ! simple test
+!  write(*,*),'--- simple test'
+  DO iCell = 1, nCells
+        IF ((xland(iCell).LT. 1.5 ) .AND. (IVGTYP(iCell) .EQ. ISWATER)) THEN
+           PRINT*, 'BEFORE MOSAIC_INIT'
+           CALL physics_message("BEFORE MOSAIC_INIT")
+           WRITE(err_message,fmt='(a,I6,F8.2,F8.2,I6,I6)') 'iCell,xland,xice,mosaic_cat_index,ivgtyp = ', &
+                 iCell,xland(iCell),xice(iCell),nLandCat,IVGTYP(iCell)
+           CALL physics_message(err_message)
+        ENDIF
+  ENDDO
+
+     DO  iCell = 1, nCells
+           DO mosaic_i=1,nLandCat
+              LANDUSEF2(mosaic_i,iCell)=LANDUSEF(mosaic_i,iCell)
+              mosaic_cat_index(mosaic_i,iCell)=mosaic_i
+           ENDDO
+
+     ENDDO
+      
+       DO iCell = 1, nCells
+       
+          NumPairs=nLandCat-1
+          
+          DO
+               IF (NumPairs == 0) EXIT
+                   LastSwap = 1
+          DO  mosaic_i=1, NumPairs
+            IF(LANDUSEF2(mosaic_i,iCell) < LANDUSEF2(mosaic_i+1,iCell)  ) THEN
+               Temp = LANDUSEF2(mosaic_i,iCell)
+               LANDUSEF2(mosaic_i,iCell)=LANDUSEF2(mosaic_i+1,iCell)
+               LANDUSEF2(mosaic_i+1,iCell)=Temp            
+               LastSwap = mosaic_i 
+            
+               Temp2 =  mosaic_cat_index(mosaic_i,iCell)
+               mosaic_cat_index(mosaic_i,iCell)=mosaic_cat_index(mosaic_i+1,iCell)
+               mosaic_cat_index(mosaic_i+1,iCell)=Temp2
+            ENDIF
+          ENDDO
+               NumPairs = LastSwap - 1
+          ENDDO
+          
+      ENDDO
+ 
+  !===========================================================================   
+  ! For non-seaice grids, eliminate the seaice-tiles
+  !=========================================================================== 
+
+     DO iCell = 1, nCells
+        
+         IF   (XLAND(iCell).LT.1.5)  THEN
+
+             ICE = 0
+                 IF( XICE(iCell).GE. XICE_THRESHOLD ) THEN
+                   WRITE (err_message,fmt='(a,2I5)') 'sea-ice at point, iCell = ', iCell
+                   CALL physics_message(err_message)
+                 ICE = 1
+                 ENDIF   
+           
+          IF (ICE == 1)   Then         ! sea-ice case , eliminate sea-ice if they are not the dominant ones
+
+          IF (IVGTYP(iCell) == isice)  THEN    ! if this grid cell is dominanted by ice, then do nothing
+
+          ELSE
+
+                DO mosaic_i=2,config_mosaic_cat
+                   IF (mosaic_cat_index(mosaic_i,iCell) == isice ) THEN
+                       Temp4=LANDUSEF2(mosaic_i,iCell)
+                       Temp5=mosaic_cat_index(mosaic_i,iCell)
+
+                       LANDUSEF2(mosaic_i:nLandCat-1,iCell)=LANDUSEF2(mosaic_i+1:nLandCat,iCell)                       
+                       mosaic_cat_index(mosaic_i:nLandCat-1,iCell)=mosaic_cat_index(mosaic_i+1:nLandCat,iCell)
+
+                       LANDUSEF2(nLandCat,iCell)=Temp4
+                       mosaic_cat_index(nLandCat,iCell)=Temp5
+                   ENDIF 
+                 ENDDO
+
+          ENDIF   ! for (IVGTYP(i,j) == isice )
+          
+          ELSEIF (ICE ==0)  THEN
+          
+          IF ((mosaic_cat_index(1,iCell) .EQ. ISWATER)) THEN    
+          
+          ! xland < 1.5 but the dominant land use category based on our calculation is water
+	             
+           IF (IVGTYP(iCell) .EQ. ISWATER) THEN  
+           
+           ! xland < 1.5 but the dominant land use category based on the geogrid calculation is water, this must be wrong
+           
+              CALL physics_message("IN MOSAIC_INIT")
+              WRITE(err_message,fmt='(a,I6,I6,F8.2,F8.2)') 'iCell,IVGTYP,XLAND,XICE = ',iCell,IVGTYP(iCell),xland(iCell),xice(iCell) 
+              CALL physics_message(err_message)
+              CALL physics_message("xland < 1.5 but the dominant land use category based on our calculation is water."//&
+                   "In addition, the dominant land use category based on the geogrid calculation is water, this must be wrong")
+           
+           ENDIF  ! for (IVGTYP(i,j) .EQ. ISWATER)
+           
+           IF (IVGTYP(iCell) .NE. ISWATER) THEN 
+           
+           ! xland < 1.5,   the dominant land use category based on our calculation is water, but based on the geogrid calculation is not water, which might be due to the inconsistence between land use data and land-sea mask
+           
+	       Temp4=LANDUSEF2(1,iCell)
+	       Temp5=mosaic_cat_index(1,iCell)
+	  
+	       LANDUSEF2(1:nLandCat-1,iCell)=LANDUSEF2(2:nLandCat,iCell)                       
+	       mosaic_cat_index(1:nLandCat-1,iCell)=mosaic_cat_index(2:nLandCat,iCell)
+	  
+	       LANDUSEF2(nLandCat,iCell)=Temp4
+	       mosaic_cat_index(nLandCat,iCell)=Temp5
+	             
+              CALL physics_message("IN MOSAIC_INIT")
+              WRITE(err_message,fmt='(a,I6,I6,F8.2,F8.2)') 'iCell,IVGTYP,XLAND,XICE = ',iCell,IVGTYP(iCell),xland(iCell),xice(iCell) 
+              CALL physics_message(err_message)
+              CALL physics_message("xland < 1.5 but the dominant land use category based on our calculation is water."//&
+                   "this is fine as long as we change our calculation so that the dominant land use category is"//&
+                   "stwiched back to not water.")
+              WRITE(err_message,fmt='(a,I6,I6)') 'land use category has been switched, before and after values are ', &
+                   temp5,mosaic_cat_index(1,iCell)
+              CALL physics_message(err_message)
+              WRITE(err_message,fmt='(a,I6,I6)') 'new dominant and second dominant cat are ', mosaic_cat_index(1,iCell),mosaic_cat_index(2,iCell)
+              CALL physics_message(err_message)
+	             
+           ENDIF  ! for (IVGTYP(iCell) .NE. ISWATER)
+          
+           ELSE    !  for (mosaic_cat_index(1,iCell) .EQ. ISWATER)
+           
+                     DO mosaic_i=2,config_mosaic_cat
+	                IF (mosaic_cat_index(mosaic_i,iCell) == iswater ) THEN
+	                   Temp4=LANDUSEF2(mosaic_i,iCell)
+	                   Temp5=mosaic_cat_index(mosaic_i,iCell)
+	   
+	                   LANDUSEF2(mosaic_i:nLandCat-1,iCell)=LANDUSEF2(mosaic_i+1:nLandCat,iCell)                       
+	                   mosaic_cat_index(mosaic_i:nLandCat-1,iCell)=mosaic_cat_index(mosaic_i+1:nLandCat,iCell)
+	  
+	                   LANDUSEF2(nLandCat,iCell)=Temp4
+	                   mosaic_cat_index(nLandCat,iCell)=Temp5
+	                ENDIF 
+	              ENDDO
+             
+           ENDIF !  for (mosaic_cat_index(1,iCell) .EQ. ISWATER)
+             
+          ENDIF  !  for ICE == 1
+          
+      ELSE  ! FOR (XLAND(iCell).LT.1.5)
+      
+                 ICE = 0
+      
+                     IF( XICE(iCell).GE. XICE_THRESHOLD ) THEN
+                       WRITE (err_message,fmt='(a,2I6)') 'sea-ice at water point, iCell = ', iCell
+                       CALL physics_message(err_message)
+                       ICE = 1
+                     ENDIF  
+      
+           IF ((mosaic_cat_index(1,iCell) .NE. ISWATER)) THEN    
+                
+                ! xland > 1.5 and the dominant land use category based on our calculation is not water
+      	             
+                 IF (IVGTYP(iCell) .NE. ISWATER) THEN  
+                 
+                 ! xland > 1.5 but the dominant land use category based on the geogrid calculation is not water, this must be wrong
+                 CALL physics_message("IN MOSAIC_INIT")
+                 WRITE(err_message,fmt='(a,I6,I6,F8.2,F8.2,I6,I6,I6)') 'iCell,IVGTYP,XLAND,XICE,ISWATER,ISICE,mosaic_cat_index = ',iCell,IVGTYP(iCell),xland(iCell),xice(iCell),iswater,isice,mosaic_cat_index(1,iCell)
+                 CALL physics_message(err_message)
+                 CALL physics_message("xland > 1.5 but the dominant land use category based on our calculation is not water."// &
+                      "in addition, the dominant land use category based on the geogrid calculation is not water,"//  &
+                      "this must be wrong.")
+                 ENDIF  ! for (IVGTYP(iCell) .NE. ISWATER)
+                 
+                 IF (IVGTYP(iCell) .EQ. ISWATER) THEN 
+                 
+                 ! xland > 1.5,   the dominant land use category based on our calculation is not water, but based on the geogrid calculation is water, which might be due to the inconsistence between land use data and land-sea mask
+
+                 CALL physics_message("IN MOSAIC_INIT")
+                 WRITE(err_message,fmt='(a,I6,I6,F8.2,F8.2,I6,I6,I6)') 'iCell,IVGTYP,XLAND,XICE,ISWATER,ISICE,mosaic_cat_index = ',iCell,IVGTYP(iCell),xland(iCell),xice(iCell),iswater,isice,mosaic_cat_index(1,iCell)
+                 CALL physics_message(err_message)
+                 CALL physics_message("xland > 1.5 but the dominant land use category based on our calculation is not water."// &
+                      "however, the dominant land use category based on the geogrid calculation is water")
+                 CALL physics_message("This is fine. We do not need to do anyting because in the noaddrv, "//&
+                      "we use xland as a criterion for whether using"// &
+                      "mosaic or not when xland > 1.5, no mosaic will be used anyway")
+      	             
+                 ENDIF  ! for (IVGTYP(iCell) .NE. ISWATER)
+                
+           ENDIF !  for (mosaic_cat_index(1,iCell) .NE. ISWATER)
+      
+        ENDIF  ! FOR (XLAND(iCell).LT.1.5)
+
+      ENDDO
+      
+!      write(*,*),'--- normalize NOAH LSM mosaic' 
+  !===========================================================================   
+  ! normalize
+  !=========================================================================== 
+
+     DO iCell = 1, nCells
+
+          Temp6=0
+
+            DO mosaic_i=1,config_mosaic_cat
+               Temp6=Temp6+LANDUSEF2(mosaic_i,iCell)
+            ENDDO
+            
+            if (Temp6 .LT. 1e-5)  then
+            
+            Temp6 = 1e-5
+            WRITE (err_message,fmt='(a,e8.1)') 'the total land surface fraction is less than ', temp6
+            CALL physics_message(err_message)
+            WRITE (err_message,fmt='(a,2I6,4F8.2)') 'some landusef values at iCell are ', &
+                 iCell,landusef2(1,iCell),landusef2(2,iCell),landusef2(3,iCell),landusef2(4,iCell)
+            CALL physics_message(err_message)
+            WRITE (err_message,fmt='(a,2I6,3I6)') 'some mosaic cat values at iCell are ', &
+                 iCell,mosaic_cat_index(1,iCell),mosaic_cat_index(2,iCell),mosaic_cat_index(3,iCell) 
+            CALL physics_message(err_message)
+            
+            endif
+
+            LANDUSEF2(1:config_mosaic_cat,iCell)=LANDUSEF2(1:config_mosaic_cat,iCell)*(1/Temp6)
+
+      ENDDO
+
+!      write(*,*),'--- initialize the NOAH LSM mosaic' 
+  !===========================================================================   
+  ! initilize the variables
+  !===========================================================================   
+
+     DO iCell = 1, nCells
+    
+             DO mosaic_i=1,config_mosaic_cat
+        
+            TSK_mosaic(mosaic_i,iCell)=skintemp(iCell)          
+            CANWAT_mosaic(mosaic_i,iCell)=CANWAT(iCell) 
+            SNOW_mosaic(mosaic_i,iCell)=SNOW(iCell) 
+            SNOWH_mosaic(mosaic_i,iCell)=SNOWH(iCell)  
+            SNOWC_mosaic(mosaic_i,iCell)=SNOWC(iCell) 
+            ALBEDO_mosaic(mosaic_i,iCell)=albedomaxtbl(ivgtyp(iCell))
+            ALBBCK_mosaic(mosaic_i,iCell)= albedomaxtbl(ivgtyp(iCell))
+            EMISS_mosaic(mosaic_i,iCell)= emissmaxtbl(ivgtyp(iCell))
+            EMBCK_mosaic(mosaic_i,iCell)= emissmaxtbl(ivgtyp(iCell))
+            ZNT_mosaic(mosaic_i,iCell)=z0maxtbl(ivgtyp(iCell))
+            Z0_mosaic(mosaic_i,iCell)=z0maxtbl(ivgtyp(iCell))
+              DO soil_k=1,nSoilLevels 
+  
+              
+             TSLB_mosaic(nSoilLevels*(mosaic_i-1)+soil_k,iCell)=TSLB(soil_k,iCell)
+             SMOIS_mosaic(nSoilLevels*(mosaic_i-1)+soil_k,iCell)=SMOIS(soil_k,iCell)
+             SH2O_mosaic(nSoilLevels*(mosaic_i-1)+soil_k,iCell)=SH2O(soil_k,iCell)
+
+         
+              ENDDO
+           
+           TR_URB2D_mosaic(mosaic_i,iCell)=skintemp(iCell)   
+           TB_URB2D_mosaic(mosaic_i,iCell)=skintemp(iCell)   
+           TG_URB2D_mosaic(mosaic_i,iCell)=skintemp(iCell)   
+           TC_URB2D_mosaic(mosaic_i,iCell)=skintemp(iCell)   
+           TS_URB2D_mosaic(mosaic_i,iCell)=skintemp(iCell)   
+           TS_RUL2D_mosaic(mosaic_i,iCell)=skintemp(iCell)   
+           QC_URB2D_mosaic(mosaic_i,iCell)=0.01
+           SH_URB2D_mosaic(mosaic_i,iCell)=0
+           LH_URB2D_mosaic(mosaic_i,iCell)=0
+           G_URB2D_mosaic(mosaic_i,iCell)=0
+           RN_URB2D_mosaic(mosaic_i,iCell)=0
+          
+          TRL_URB3D_mosaic(4*(mosaic_i-1)+1,iCell)=TSLB(1,iCell)+0.
+          TRL_URB3D_mosaic(4*(mosaic_i-1)+2,iCell)=0.5*(TSLB(1,iCell)+TSLB(2,iCell))
+          TRL_URB3D_mosaic(4*(mosaic_i-1)+3,iCell)=TSLB(2,iCell)+0.
+          TRL_URB3D_mosaic(4*(mosaic_i-1)+4,iCell)=TSLB(2,iCell)+(TSLB(3,iCell)-TSLB(2,iCell))*0.29
+
+          TBL_URB3D_mosaic(4*(mosaic_i-1)+1,iCell)=TSLB(1,iCell)+0.
+          TBL_URB3D_mosaic(4*(mosaic_i-1)+2,iCell)=0.5*(TSLB(1,iCell)+TSLB(2,iCell))
+          TBL_URB3D_mosaic(4*(mosaic_i-1)+3,iCell)=TSLB(2,iCell)+0.
+          TBL_URB3D_mosaic(4*(mosaic_i-1)+4,iCell)=TSLB(2,iCell)+(TSLB(3,iCell)-TSLB(2,iCell))*0.29           
+                    
+          TGL_URB3D_mosaic(4*(mosaic_i-1)+1,iCell)=TSLB(1,iCell)
+          TGL_URB3D_mosaic(4*(mosaic_i-1)+2,iCell)=TSLB(2,iCell)
+          TGL_URB3D_mosaic(4*(mosaic_i-1)+3,iCell)=TSLB(3,iCell)
+          TGL_URB3D_mosaic(4*(mosaic_i-1)+4,iCell)=TSLB(4,iCell)
+         
+          
+            ENDDO
+      ENDDO
+!write(*,*),'--- Done initialize the NOAH LSM mosaic'
+!write(*,*),'--- TSK Mosaic= ', TSK_mosaic
+!write(*,*),'--- CANWAT Mosaic= ', CANWAT_mosaic
+!write(*,*),'--- Albedo Mosaic= ', ALBEDO_mosaic
+!write(*,*),'--- TSLB Mosaic= ', TSLB_mosaic
+!write(*,*),'--- TR_URB2D Mosaic= ', TR_URB2D_mosaic
+!write(*,*),'--- TRL_URB3D Mosaic= ', TRL_URB3D_mosaic
+   ! simple test
+   
+       DO iCell = 1, nCells
+   
+           IF ((xland(iCell).LT. 1.5 ) .AND. (mosaic_cat_index(1,iCell) .EQ. ISWATER)) THEN
+             CALL physics_message("After MOSAIC_INIT")
+             WRITE (err_message,fmt='(a,I6,F8.2,F8.2,I6,I6)') 'weird xland,xice,mosaic_cat_index and ivgtyp at iCell = ', &
+                iCell,xland(iCell),xice(iCell),mosaic_cat_index(1,iCell),IVGTYP(iCell)
+             CALL physics_message(err_message)
+           ENDIF
+           
+      ENDDO
+
+          ENDIF  ! For config_lsm_mosaic
+
+
+ endif !for not restart
+!write(*,*),'--- Leaving LSM initialization'
  end subroutine lsminit
 
 !=================================================================================================================

--- a/src/core_atmosphere/physics/mpas_atmphys_manager.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_manager.F
@@ -98,7 +98,8 @@
 ! * added initialization of variables has_reqc,has_reqi,and has_reqs needed in the calls to radiation codes
 !   rrtmg_lwrad and rrmtg_swrad.
 !   Laura D. Fowler (laura@ucar.edu) / 2016-07-007.
-
+!   Added Noah Mosaic LSM dimensions.
+!   Patrick Campbell (campbell.patrickc@epa.gov)  2017-08-03
 
  contains
 
@@ -383,7 +384,7 @@
  integer,pointer:: cam_dim1
  integer,pointer:: nMonths
  integer,pointer:: nAerosols,nAerLevels,nOznLevels
- integer,pointer:: nCellsSolve,nSoilLevels,nVertLevels
+ integer,pointer:: nCellsSolve,nSoilLevels,nVertLevels,nLandCat,nMosaicCat,nMosaicCat3D
 
  real(kind=RKIND),pointer:: config_dt
 
@@ -428,8 +429,10 @@
  call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
  call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
  call mpas_pool_get_dimension(mesh,'nSoilLevels',nSoilLevels)
+ call mpas_pool_get_dimension(mesh,'nLandCat'   ,nLandCat   )
+ call mpas_pool_get_dimension(mesh,'nMosaicCat' ,nMosaicCat )
+ call mpas_pool_get_dimension(mesh,'nMosaicCat3D'   ,nMosaicCat3D)
  call mpas_pool_get_dimension(mesh,'nVertLevels',nVertLevels)
-
  call mpas_pool_get_dimension(state,'num_aerosols',nAerosols)
 
 !initialization of gmt, julian day, and alarms:
@@ -661,6 +664,9 @@
 !initialization local physics variables:
  num_months = nMonths
  num_soils  = nSoilLevels
+ num_landu  = nLandCat
+ num_mosaic_cat = nMosaicCat
+ num_mosaic_cat3d = nMosaicCat3D
 
  convection_scheme = trim(config_convection_scheme)
  lsm_scheme        = trim(config_lsm_scheme)

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -68,7 +68,8 @@
 ! * moved the declarations of arrays delta_p,wstar_p,uoce_p,and voce_p since they are now used in both modules
 !   module_bl_ysu.F and module_bl_mynn.F.
 !   Laura D. Fowler (laura@ucar.edu) / 20016-10-27.
-
+!   Added Noah Mosaic Variables 
+!   Patrick Campbell (campbell.patrickc@epa.gov)  2017-08-03
 
 !=================================================================================================================
 !list of physics parameterizations:
@@ -589,20 +590,44 @@
                        !albedos as functions of the land surface scheme.
 
  integer,public:: &
-    num_soils          !number of soil layers                                                                  [-]
-    
+    num_soils,         &!number of soil layers                                                                  [-]
+    num_landu,         &!number of landuse classes                                                              [-]
+    num_mosaic_cat,    &!number of user selected mosaic categories                                              [-]  !PCC For Mosaic
+    num_mosaic_cat3d    !number of user selected mosaic categories * num_soils                                  [-]  !PCC For Mosaic
  integer,dimension(:,:),allocatable:: &
     isltyp_p,         &!dominant soil type category                                                            [-]
     ivgtyp_p           !dominant vegetation category                                                           [-]
-
+ integer,dimension(:,:,:),allocatable:: &
+    mosaic_cat_index_p  !mosaic category land use tile index                                                    [-]  !PCC For Mosaic 
  real(kind=RKIND),dimension(:),allocatable:: &
     dzs_p              !thickness of soil layers                                                               [m]
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
-    smcrel_p,         &!soil moisture threshold below which transpiration starts to stress                     [-]
-    sh2o_p,           &!unfrozen soil moisture content                                       [volumetric fraction]
-    smois_p,          &!soil moisture                                                        [volumetric fraction]
-    tslb_p             !soil temperature                                                                       [K]
-
+    smcrel_p,           &!soil moisture threshold below which transpiration starts to stress                     [-]
+    sh2o_p,             &!unfrozen soil moisture content                                       [volumetric fraction]
+    smois_p,            &!soil moisture                                                        [volumetric fraction]
+    tslb_p,             &!soil temperature                                                                       [K]
+    landusef_p,         &!fractional landuse                                                                     [-]PCC For Mosaic...
+    landusef2_p,        &!fractional landuse mosaic                                                              [-]         
+    TSK_mosaic_p,       &!ground or water surface temperature mosaic						 [K]			     
+    CANWAT_mosaic_p,    &!canopy water                                                                       [kg/m2]
+    SNOW_mosaic_p,      &!snow water equivalent								     [kg/m2]
+    SNOWH_mosaic_p,     &!physical snow depth									 [m] 
+    SNOWC_mosaic_p,     &!flag indicating snow coverage                                                          [-]
+    ALBEDO_mosaic_p,    &!albedo                                                                                 [-]
+    ALBBCK_mosaic_p,    &!background albedo 									 [-]
+    EMISS_mosaic_p,     &!emissivity mosaic									 [-]
+    EMBCK_mosaic_p,    &!background emissivity 									 [-]
+    ZNT_mosaic_p,       &!time dependent roughness length 							 [m]
+    Z0_mosaic_p,        &!time indenpendent roughness length							 [m]
+    QSFC_mosaic_p,      &!surface mixing ratio 								     [kg/kg]
+    HFX_mosaic_p,       &!upward heat flux at the surface 						      [W/m2]
+    QFX_mosaic_p,       &!upward moisture flux at the surface					           [kg/m2/s]
+    LH_mosaic_p,        &!latent heat flux at the surface                                                     [W/m2]  
+    GRDFLX_mosaic_p,    &!ground heat flux                						      [W/m2]
+    SNOTIME_mosaic_p,   &!initial number of time steps since last snowfall                                       [-]
+    TSLB_mosaic_p,      &!soil temperature                                                                       [K]
+    SH2O_mosaic_p,      &!soil water content                                                                 [m3/m3]
+    SMOIS_mosaic_p       !soil moisture                                                                      [m3/m3]
  real(kind=RKIND),dimension(:,:),allocatable:: &
     acsnom_p,         &!accumulated melted snow                                                           [kg m-2]
     acsnow_p,         &!accumulated snow                                                                  [kg m-2]

--- a/src/core_atmosphere/physics/physics_wrf/module_sf_noahdrv.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_noahdrv.F
@@ -1693,7 +1693,7 @@ CONTAINS
           CALL wrf_error_fatal ( message )
         END IF
 
-        WRITE(mess,*) 'INPUT SOIL TEXTURE CLASSIFICAION = ', TRIM ( MMINSL )
+        WRITE(mess,*) 'INPUT SOIL TEXTURE CLASSIFICATION = ', TRIM ( MMINSL )
         CALL wrf_message( mess )
 
         LUMATCH=0
@@ -1828,7 +1828,2580 @@ CONTAINS
 !-----------------------------------------------------------------
       END SUBROUTINE SOIL_VEG_GEN_PARM
 !-----------------------------------------------------------------
-
 #endif
+!===========================================================================
+!
+! subroutine lsm_mosaic: a tiling approach for Noah LSM (Li et al., 2013)
+! Added/modified for MPAS by Patrick Campbell (campbell.patrickc@epa.gov)
+! 2017-08-03
+!=========================================================================== 
 
+SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
+                  HFX,QFX,LH,GRDFLX, QGH,GSW,SWDOWN,GLW,SMSTAV,SMSTOT, &
+                  SFCRUNOFF, UDRUNOFF,IVGTYP,ISLTYP,ISURBAN,ISICE,VEGFRA,    &
+                  ALBEDO,ALBBCK,ZNT,Z0,TMN,XLAND,XICE,EMISS,EMBCK,   &
+                  SNOWC,QSFC,RAINBL,MMINLU,                     &
+                  num_soil_layers,DT,DZS,ITIMESTEP,             &
+                  SMOIS,TSLB,SNOW,CANWAT,                       &
+                  CHS,CHS2,CQS2,CPM,ROVCP,SR,chklowq,lai,qz0,   & !H
+                  myj,frpcpn,                                   &
+                  SH2O,SNOWH,                                   & !H
+                  U_PHY,V_PHY,                                  & !I
+                  SNOALB,SHDMIN,SHDMAX,                         & !I
+                  SNOTIME,                                      & !?
+                  ACSNOM,ACSNOW,                                & !O
+                  SNOPCX,                                       & !O
+                  POTEVP,                                       & !O
+                  SMCREL,                                       & !O
+                  XICE_THRESHOLD,                               &
+                  RDLAI2D,USEMONALB,                            &
+                  RIB,                                          & !?
+                  NOAHRES,                                      &
+                 NLCAT,landusef,landusef2,                       & ! danli mosaic
+                 sf_surface_mosaic,mosaic_cat,mosaic_cat_index,  & ! danli mosaic 
+                 TSK_mosaic,QSFC_mosaic,                         & ! danli mosaic 
+                 TSLB_mosaic,SMOIS_mosaic,SH2O_mosaic,           & ! danli mosaic 
+                 CANWAT_mosaic,SNOW_mosaic,                      & ! danli mosaic
+                 SNOWH_mosaic,SNOWC_mosaic,                      & ! danli mosaic 
+                 ALBEDO_mosaic,ALBBCK_mosaic,                    & ! danli mosaic
+                 EMISS_mosaic, EMBCK_mosaic,                     & ! danli mosaic
+                 ZNT_mosaic, Z0_mosaic,                          & ! danli mosaic 
+                 HFX_mosaic,QFX_mosaic,                          & ! danli mosaic
+                 LH_mosaic, GRDFLX_mosaic, SNOTIME_mosaic,       & ! danli mosaic                   
+                  ids,ide, jds,jde, kds,kde,                    &
+                  ims,ime, jms,jme, kms,kme,                    &
+                  its,ite, jts,jte, kts,kte,                    &
+                  sf_urban_physics,                             &
+                  CMR_SFCDIF,CHR_SFCDIF,CMC_SFCDIF,CHC_SFCDIF,  &
+!Optional Urban
+                  TR_URB2D,TB_URB2D,TG_URB2D,TC_URB2D,QC_URB2D, & !H urban
+                  UC_URB2D,                                     & !H urban
+                  XXXR_URB2D,XXXB_URB2D,XXXG_URB2D,XXXC_URB2D,  & !H urban
+                  TRL_URB3D,TBL_URB3D,TGL_URB3D,                & !H urban
+                  SH_URB2D,LH_URB2D,G_URB2D,RN_URB2D,TS_URB2D,  & !H urban
+                  TR_URB2D_mosaic,TB_URB2D_mosaic,              & !H urban  danli mosaic
+                  TG_URB2D_mosaic,TC_URB2D_mosaic,              & !H urban  danli mosaic
+                  QC_URB2D_mosaic,UC_URB2D_mosaic,              & !H urban  danli mosaic                  
+                  TRL_URB3D_mosaic,TBL_URB3D_mosaic,            & !H urban  danli mosaic
+                  TGL_URB3D_mosaic,                             & !H urban  danli mosaic
+                  SH_URB2D_mosaic,LH_URB2D_mosaic,              & !H urban  danli mosaic
+                  G_URB2D_mosaic,RN_URB2D_mosaic,               & !H urban  danli mosaic
+                  TS_URB2D_mosaic,                              & !H urban  danli mosaic
+                  TS_RUL2D_mosaic,                              & !H urban  danli mosaic                  
+                  PSIM_URB2D,PSIH_URB2D,U10_URB2D,V10_URB2D,    & !O urban
+                  GZ1OZ0_URB2D,  AKMS_URB2D,                    & !O urban
+                  TH2_URB2D,Q2_URB2D, UST_URB2D,                & !O urban
+                  DECLIN_URB,COSZ_URB2D,OMG_URB2D,              & !I urban
+                  XLAT_URB2D,                                   & !I urban
+                  num_roof_layers, num_wall_layers,             & !I urban
+                  num_road_layers, DZR, DZB, DZG,               & !I urban
+                  FRC_URB2D,UTYPE_URB2D,                        & !O
+                  num_urban_layers,                             & !I multi-layer urban
+                  trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d,      & !H multi-layer urban
+                  tlev_urb3d,qlev_urb3d,                        & !H multi-layer urban
+                  tw1lev_urb3d,tw2lev_urb3d,                    & !H multi-layer urban
+                  tglev_urb3d,tflev_urb3d,                      & !H multi-layer urban
+                  sf_ac_urb3d,lf_ac_urb3d,cm_ac_urb3d,          & !H multi-layer urban
+                  sfvent_urb3d,lfvent_urb3d,                    & !H multi-layer urban
+                  sfwin1_urb3d,sfwin2_urb3d,                    & !H multi-layer urban
+                  sfw1_urb3d,sfw2_urb3d,sfr_urb3d,sfg_urb3d,    & !H multi-layer urban
+                  th_phy,rho,p_phy,ust,                         & !I multi-layer urban
+                  gmt,julday,xlong,xlat,                        & !I multi-layer urban
+                  a_u_bep,a_v_bep,a_t_bep,a_q_bep,              & !O multi-layer urban
+                  a_e_bep,b_u_bep,b_v_bep,                      & !O multi-layer urban
+                  b_t_bep,b_q_bep,b_e_bep,dlg_bep,              & !O multi-layer urban
+                  dl_u_bep,sf_bep,vl_bep                        & !O multi-layer urban
+                  )
+
+!----------------------------------------------------------------
+    IMPLICIT NONE
+!----------------------------------------------------------------
+!----------------------------------------------------------------
+! --- atmospheric (WRF generic) variables
+!-- DT          time step (seconds)
+!-- DZ8W        thickness of layers (m)
+!-- T3D         temperature (K)
+!-- QV3D        3D water vapor mixing ratio (Kg/Kg)
+!-- P3D         3D pressure (Pa)
+!-- FLHC        exchange coefficient for heat (m/s)
+!-- FLQC        exchange coefficient for moisture (m/s)
+!-- PSFC        surface pressure (Pa)
+!-- XLAND       land mask (1 for land, 2 for water)
+!-- QGH         saturated mixing ratio at 2 meter
+!-- GSW         downward short wave flux at ground surface (W/m^2)
+!-- GLW         downward long wave flux at ground surface (W/m^2)
+!-- History variables
+!-- CANWAT      canopy moisture content (mm)
+!-- TSK         surface temperature (K)
+!-- TSLB        soil temp (k)
+!-- SMOIS       total soil moisture content (volumetric fraction)
+!-- SH2O        unfrozen soil moisture content (volumetric fraction)
+!                note: frozen soil moisture (i.e., soil ice) = SMOIS - SH2O
+!-- SNOWH       actual snow depth (m)
+!-- SNOW        liquid water-equivalent snow depth (m)
+!-- ALBEDO      time-varying surface albedo including snow effect (unitless fraction)
+!-- ALBBCK      background surface albedo (unitless fraction)
+!-- CHS          surface exchange coefficient for heat and moisture (m s-1);
+!-- CHS2        2m surface exchange coefficient for heat  (m s-1);
+!-- CQS2        2m surface exchange coefficient for moisture (m s-1);
+! --- soil variables
+!-- num_soil_layers   the number of soil layers
+!-- ZS          depths of centers of soil layers   (m)
+!-- DZS         thicknesses of soil layers (m)
+!-- SLDPTH      thickness of each soil layer (m, same as DZS)
+!-- TMN         soil temperature at lower boundary (K)
+!-- SMCWLT      wilting point (volumetric)
+!-- SMCDRY      dry soil moisture threshold where direct evap from
+!               top soil layer ends (volumetric)
+!-- SMCREF      soil moisture threshold below which transpiration begins to
+!                   stress (volumetric)
+!-- SMCMAX      porosity, i.e. saturated value of soil moisture (volumetric)
+!-- NROOT       number of root layers, a function of veg type, determined
+!               in subroutine redprm.
+!-- SMSTAV      Soil moisture availability for evapotranspiration (
+!                   fraction between SMCWLT and SMCMXA)
+!-- SMSTOT      Total soil moisture content frozen+unfrozen) in the soil column (mm)
+! --- snow variables
+!-- SNOWC       fraction snow coverage (0-1.0)
+! --- vegetation variables
+!-- SNOALB      upper bound on maximum albedo over deep snow
+!-- SHDMIN      minimum areal fractional coverage of annual green vegetation
+!-- SHDMAX      maximum areal fractional coverage of annual green vegetation
+!-- XLAI        leaf area index (dimensionless)
+!-- Z0BRD       Background fixed roughness length (M)
+!-- Z0          Background vroughness length (M) as function
+!-- ZNT         Time varying roughness length (M) as function
+!-- ALBD(IVGTPK,ISN) background albedo reading from a table
+! --- LSM output
+!-- HFX         upward heat flux at the surface (W/m^2)
+!-- QFX         upward moisture flux at the surface (kg/m^2/s)
+!-- LH          upward moisture flux at the surface (W m-2)
+!-- GRDFLX(I,J) ground heat flux (W m-2)
+!-- FDOWN       radiation forcing at the surface (W m-2) = SOLDN*(1-alb)+LWDN
+!----------------------------------------------------------------------------
+!-- EC          canopy water evaporation ((W m-2)
+!-- EDIR        direct soil evaporation (W m-2)
+!-- ET          plant transpiration from a particular root layer (W m-2)
+!-- ETT         total plant transpiration (W m-2)
+!-- ESNOW       sublimation from (or deposition to if <0) snowpack (W m-2)
+!-- DRIP        through-fall of precip and/or dew in excess of canopy
+!                 water-holding capacity (m)
+!-- DEW         dewfall (or frostfall for t<273.15) (M)
+!-- SMAV        Soil Moisture Availability for each layer, as a fraction
+!                 between SMCWLT and SMCMAX (dimensionless fraction)
+! ----------------------------------------------------------------------
+!-- BETA        ratio of actual/potential evap (dimensionless)
+!-- ETP         potential evaporation (W m-2)
+! ----------------------------------------------------------------------
+!-- FLX1        precip-snow sfc (W m-2)
+!-- FLX2        freezing rain latent heat flux (W m-2)
+!-- FLX3        phase-change heat flux from snowmelt (W m-2)
+! ----------------------------------------------------------------------
+!-- ACSNOM      snow melt (mm) (water equivalent)
+!-- ACSNOW      accumulated snow fall (mm) (water equivalent)
+!-- SNOPCX      snow phase change heat flux (W/m^2)
+!-- POTEVP      accumulated potential evaporation (m)
+!-- RIB         Documentation needed!!!
+! ----------------------------------------------------------------------
+!-- RUNOFF1     surface runoff (m s-1), not infiltrating the surface
+!-- RUNOFF2     subsurface runoff (m s-1), drainage out bottom of last
+!                  soil layer (baseflow)
+!  important note: here RUNOFF2 is actually the sum of RUNOFF2 and RUNOFF3
+!-- RUNOFF3     numerical trunctation in excess of porosity (smcmax)
+!                  for a given soil layer at the end of a time step (m s-1).
+! ----------------------------------------------------------------------
+!-- RC          canopy resistance (s m-1)
+!-- PC          plant coefficient (unitless fraction, 0-1) where PC*ETP = actual transp
+!-- RSMIN       minimum canopy resistance (s m-1)
+!-- RCS         incoming solar rc factor (dimensionless)
+!-- RCT         air temperature rc factor (dimensionless)
+!-- RCQ         atmos vapor pressure deficit rc factor (dimensionless)
+!-- RCSOIL      soil moisture rc factor (dimensionless)
+
+!-- EMISS       surface emissivity (between 0 and 1)
+!-- EMBCK       Background surface emissivity (between 0 and 1)
+
+!-- ROVCP       R/CP
+!               (R_d/R_v) (dimensionless)
+!-- ids         start index for i in domain
+!-- ide         end index for i in domain
+!-- jds         start index for j in domain
+!-- jde         end index for j in domain
+!-- kds         start index for k in domain
+!-- kde         end index for k in domain
+!-- ims         start index for i in memory
+!-- ime         end index for i in memory
+!-- jms         start index for j in memory
+!-- jme         end index for j in memory
+!-- kms         start index for k in memory
+!-- kme         end index for k in memory
+!-- its         start index for i in tile
+!-- ite         end index for i in tile
+!-- jts         start index for j in tile
+!-- jte         end index for j in tile
+!-- kts         start index for k in tile
+!-- kte         end index for k in tile
+!
+!-- SR          fraction of frozen precip (0.0 to 1.0)
+!----------------------------------------------------------------
+
+! IN only
+
+   INTEGER,  INTENT(IN   )   ::     ids,ide, jds,jde, kds,kde,  &
+                                    ims,ime, jms,jme, kms,kme,  &
+                                    its,ite, jts,jte, kts,kte
+
+   INTEGER,  INTENT(IN   )   ::  sf_urban_physics               !urban
+   INTEGER,  INTENT(IN   )   ::  isurban
+   INTEGER,  INTENT(IN   )   ::  isice
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(IN   )    ::                            TMN, &
+                                                         XLAND, &
+                                                          XICE, &
+                                                        VEGFRA, &
+                                                        SHDMIN, &
+                                                        SHDMAX, &
+                                                        SNOALB, &
+                                                           GSW, &
+                                                        SWDOWN, & !added 10 jan 2007
+                                                           GLW, &
+                                                        RAINBL, &
+                                                        SR
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(INOUT)    ::                         ALBBCK, &
+                                                            Z0, &
+                                                         EMBCK                  ! danli mosaic
+                                                         
+   CHARACTER(LEN=*), INTENT(IN   )    ::                 MMINLU
+
+   REAL,    DIMENSION( ims:ime, kms:kme, jms:jme )            , &
+            INTENT(IN   )    ::                           QV3D, &
+                                                         p8w3D, &
+                                                          DZ8W, &
+                                                          T3D
+   REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+             INTENT(IN   )               ::               QGH,  &
+                                                          CPM
+
+   INTEGER, DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(IN   )    ::                          ISLTYP
+                                                        
+   INTEGER, DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(INOUT   )    ::                         IVGTYP                   ! for mosaic danli
+
+   INTEGER, INTENT(IN)       ::     num_soil_layers,ITIMESTEP
+
+   REAL,     INTENT(IN   )   ::     DT,ROVCP
+
+   REAL,     DIMENSION(1:num_soil_layers), INTENT(IN)::DZS
+
+! IN and OUT
+
+   REAL,     DIMENSION( ims:ime , 1:num_soil_layers, jms:jme ), &
+             INTENT(INOUT)   ::                          SMOIS, & ! total soil moisture
+                                                         SH2O,  & ! new soil liquid
+                                                         TSLB     ! TSLB     STEMP
+
+   REAL,     DIMENSION( ims:ime , 1:num_soil_layers, jms:jme ), &
+             INTENT(INOUT)     ::                         SMCREL
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(INOUT)    ::                            TSK, & !was TGB (temperature)
+                                                           HFX, &
+                                                           QFX, &
+                                                            LH, &
+                                                        GRDFLX, &
+                                                          QSFC,&
+                                                          CQS2,&
+                                                          CHS,   &
+                                                          CHS2,&
+                                                          SNOW, &
+                                                         SNOWC, &
+                                                         SNOWH, & !new
+                                                        CANWAT, &
+                                                        SMSTAV, &
+                                                        SMSTOT, &
+                                                     SFCRUNOFF, &
+                                                      UDRUNOFF, &
+                                                        ACSNOM, &
+                                                        ACSNOW, &
+                                                       SNOTIME, &
+                                                        SNOPCX, &
+                                                        EMISS,  &
+                                                          RIB,  &
+                                                        POTEVP, &
+                                                        ALBEDO, &
+                                                           ZNT
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(INOUT)      ::                         NOAHRES
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+               INTENT(INOUT)    ::                        CHKLOWQ
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: LAI
+   REAL,DIMENSION(IMS:IME,JMS:JME),INTENT(IN) ::        QZ0
+
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CMR_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CHR_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CMC_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CHC_SFCDIF
+! Local variables (moved here from driver to make routine thread safe, 20031007 jm)
+
+      REAL, DIMENSION(1:num_soil_layers) ::  ET
+
+      REAL, DIMENSION(1:num_soil_layers) ::  SMAV
+
+      REAL  ::  BETA, ETP, SSOIL,EC, EDIR, ESNOW, ETT,        &
+                FLX1,FLX2,FLX3, DRIP,DEW,FDOWN,RC,PC,RSMIN,XLAI,  &
+!                RCS,RCT,RCQ,RCSOIL
+                RCS,RCT,RCQ,RCSOIL,FFROZP
+
+    LOGICAL,    INTENT(IN   )    ::     myj,frpcpn
+
+! DECLARATIONS - LOGICAL
+! ----------------------------------------------------------------------
+      LOGICAL, PARAMETER :: LOCAL=.false.
+      LOGICAL :: FRZGRA, SNOWNG
+
+      LOGICAL :: IPRINT
+
+! ----------------------------------------------------------------------
+! DECLARATIONS - INTEGER
+! ----------------------------------------------------------------------
+      INTEGER :: I,J, ICE,NSOIL,SLOPETYP,SOILTYP,VEGTYP
+      INTEGER :: NROOT
+      INTEGER :: KZ ,K
+      INTEGER :: NS
+! ----------------------------------------------------------------------
+! DECLARATIONS - REAL
+! ----------------------------------------------------------------------
+
+      REAL  :: SHMIN,SHMAX,DQSDT2,LWDN,PRCP,PRCPRAIN,                    &
+               Q2SAT,Q2SATI,SFCPRS,SFCSPD,SFCTMP,SHDFAC,SNOALB1,         &
+               SOLDN,TBOT,ZLVL, Q2K,ALBBRD, ALBEDOK, ETA, ETA_KINEMATIC, &
+               EMBRD,                                                    &
+               Z0K,RUNOFF1,RUNOFF2,RUNOFF3,SHEAT,SOLNET,E2SAT,SFCTSNO,   &
+! mek, WRF testing, expanded diagnostics
+               SOLUP,LWUP,RNET,RES,Q1SFC,TAIRV,SATFLG
+! MEK MAY 2007
+      REAL ::  FDTLIW
+! MEK JUL2007 for pot. evap.
+      REAL :: RIBB
+      REAL ::  FDTW
+
+      REAL  :: EMISSI
+
+      REAL  :: SNCOVR,SNEQV,SNOWHK,CMC, CHK,TH2
+
+      REAL  :: SMCDRY,SMCMAX,SMCREF,SMCWLT,SNOMLT,SOILM,SOILW,Q1,T1
+      REAL  :: SNOTIME1    ! LSTSNW1 INITIAL NUMBER OF TIMESTEPS SINCE LAST SNOWFALL
+
+      REAL  :: DUMMY,Z0BRD
+!
+      REAL  :: COSZ, SOLARDIRECT
+!
+      REAL, DIMENSION(1:num_soil_layers)::  SLDPTH, STC,SMC,SWC
+!
+      REAL, DIMENSION(1:num_soil_layers) ::     ZSOIL, RTDIS
+      REAL, PARAMETER  :: TRESH=.95E0, A2=17.67,A3=273.15,A4=29.65,   &
+                          T0=273.16E0, ELWV=2.50E6,  A23M4=A2*(A3-A4)
+! MEK MAY 2007
+      REAL, PARAMETER  :: ROW=1.E3,ELIW=XLF,ROWLIW=ROW*ELIW
+
+! ----------------------------------------------------------------------
+! DECLARATIONS START - urban
+! ----------------------------------------------------------------------
+
+! input variables surface_driver --> lsm
+     INTEGER, INTENT(IN) :: num_roof_layers
+     INTEGER, INTENT(IN) :: num_wall_layers
+     INTEGER, INTENT(IN) :: num_road_layers
+     REAL, OPTIONAL, DIMENSION(1:num_roof_layers), INTENT(IN) :: DZR
+     REAL, OPTIONAL, DIMENSION(1:num_wall_layers), INTENT(IN) :: DZB
+     REAL, OPTIONAL, DIMENSION(1:num_road_layers), INTENT(IN) :: DZG
+     REAL, OPTIONAL, INTENT(IN) :: DECLIN_URB
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: COSZ_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: OMG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: XLAT_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: U_PHY
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: V_PHY
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: TH_PHY
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: P_PHY
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: RHO
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: UST
+
+     LOGICAL, intent(in) :: rdlai2d
+     LOGICAL, intent(in) :: USEMONALB
+
+! input variables lsm --> urban
+     INTEGER :: UTYPE_URB ! urban type [urban=1, suburban=2, rural=3]
+     REAL :: TA_URB       ! potential temp at 1st atmospheric level [K]
+     REAL :: QA_URB       ! mixing ratio at 1st atmospheric level  [kg/kg]
+     REAL :: UA_URB       ! wind speed at 1st atmospheric level    [m/s]
+     REAL :: U1_URB       ! u at 1st atmospheric level             [m/s]
+     REAL :: V1_URB       ! v at 1st atmospheric level             [m/s]
+     REAL :: SSG_URB      ! downward total short wave radiation    [W/m/m]
+     REAL :: LLG_URB      ! downward long wave radiation           [W/m/m]
+     REAL :: RAIN_URB     ! precipitation                          [mm/h]
+     REAL :: RHOO_URB     ! air density                            [kg/m^3]
+     REAL :: ZA_URB       ! first atmospheric level                [m]
+     REAL :: DELT_URB     ! time step                              [s]
+     REAL :: SSGD_URB     ! downward direct short wave radiation   [W/m/m]
+     REAL :: SSGQ_URB     ! downward diffuse short wave radiation  [W/m/m]
+     REAL :: XLAT_URB     ! latitude                               [deg]
+     REAL :: COSZ_URB     ! cosz
+     REAL :: OMG_URB      ! hour angle
+     REAL :: ZNT_URB      ! roughness length                       [m]
+     REAL :: TR_URB
+     REAL :: TB_URB
+     REAL :: TG_URB
+     REAL :: TC_URB
+     REAL :: QC_URB
+     REAL :: UC_URB
+     REAL :: XXXR_URB
+     REAL :: XXXB_URB
+     REAL :: XXXG_URB
+     REAL :: XXXC_URB
+     REAL, DIMENSION(1:num_roof_layers) :: TRL_URB  ! roof layer temp [K]
+     REAL, DIMENSION(1:num_wall_layers) :: TBL_URB  ! wall layer temp [K]
+     REAL, DIMENSION(1:num_road_layers) :: TGL_URB  ! road layer temp [K]
+     LOGICAL  :: LSOLAR_URB
+
+! state variable surface_driver <--> lsm <--> urban
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TB_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TC_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: QC_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: UC_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: XXXR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: XXXB_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: XXXG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: XXXC_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: SH_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: LH_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: G_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: RN_URB2D
+!
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TS_URB2D
+
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_roof_layers, jms:jme ), INTENT(INOUT) :: TRL_URB3D
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_wall_layers, jms:jme ), INTENT(INOUT) :: TBL_URB3D
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_road_layers, jms:jme ), INTENT(INOUT) :: TGL_URB3D
+
+! output variable lsm --> surface_driver
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: PSIM_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: PSIH_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: GZ1OZ0_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: U10_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: V10_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TH2_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: Q2_URB2D
+!
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: AKMS_URB2D
+!
+!ldf(01-18-2011)
+!     REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: UST_URB2D
+!     REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: FRC_URB2D                ! change this to inout, danli mosaic
+!     INTEGER, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: UTYPE_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: UST_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: FRC_URB2D                ! change this to inout, danli mosaic
+     INTEGER, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: UTYPE_URB2D
+!end ldf
+! output variables urban --> lsm
+     REAL :: TS_URB     ! surface radiative temperature    [K]
+     REAL :: QS_URB     ! surface humidity                 [-]
+     REAL :: SH_URB     ! sensible heat flux               [W/m/m]
+     REAL :: LH_URB     ! latent heat flux                 [W/m/m]
+     REAL :: LH_KINEMATIC_URB ! latent heat flux, kinetic  [kg/m/m/s]
+     REAL :: SW_URB     ! upward short wave radiation flux [W/m/m]
+     REAL :: ALB_URB    ! time-varying albedo            [fraction]
+     REAL :: LW_URB     ! upward long wave radiation flux  [W/m/m]
+     REAL :: G_URB      ! heat flux into the ground        [W/m/m]
+     REAL :: RN_URB     ! net radiation                    [W/m/m]
+     REAL :: PSIM_URB   ! shear f for momentum             [-]
+     REAL :: PSIH_URB   ! shear f for heat                 [-]
+     REAL :: GZ1OZ0_URB   ! shear f for heat                 [-]
+     REAL :: U10_URB    ! wind u component at 10 m         [m/s]
+     REAL :: V10_URB    ! wind v component at 10 m         [m/s]
+     REAL :: TH2_URB    ! potential temperature at 2 m     [K]
+     REAL :: Q2_URB     ! humidity at 2 m                  [-]
+     REAL :: CHS_URB
+     REAL :: CHS2_URB
+     REAL :: UST_URB
+! Variables for multi-layer UCM (Martilli et al. 2002)
+   REAL, OPTIONAL, INTENT(IN  )   ::                                   GMT 
+   INTEGER, OPTIONAL, INTENT(IN  ) ::                               JULDAY
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN   )        ::XLAT, XLONG
+!ldf (01-18-2011):
+   INTEGER, INTENT(IN  ) ::                               NUM_URBAN_LAYERS
+!end ldf. 
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: trb_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw1_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw2_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tgb_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tlev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: qlev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw1lev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw2lev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tglev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tflev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: lf_ac_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: sf_ac_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: cm_ac_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: sfvent_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: lfvent_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfwin1_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfwin2_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfw1_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfw2_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfr_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfg_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::a_u_bep   !Implicit momemtum component X-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::a_v_bep   !Implicit momemtum component Y-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::a_t_bep   !Implicit component pot. temperature
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::a_q_bep   !Implicit momemtum component X-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::a_e_bep   !Implicit component TKE
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::b_u_bep   !Explicit momentum component X-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::b_v_bep   !Explicit momentum component Y-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::b_t_bep   !Explicit component pot. temperature
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::b_q_bep   !Implicit momemtum component Y-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::b_e_bep   !Explicit component TKE
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::vl_bep    !Fraction air volume in grid cell
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::dlg_bep   !Height above ground
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::sf_bep  !Fraction air at the face of grid cell
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::dl_u_bep  !Length scale
+
+! Local variables for multi-layer UCM (Martilli et al. 2002)
+   REAL,    DIMENSION( ims:ime, jms:jme ) :: HFX_RURAL,LH_RURAL,GRDFLX_RURAL, RN_RURAL
+   REAL,    DIMENSION( ims:ime, jms:jme ) :: QFX_RURAL ,QSFC_RURAL,UMOM_RURAL,VMOM_RURAL
+   REAL,    DIMENSION( ims:ime, jms:jme ) :: ALB_RURAL,EMISS_RURAL,TSK_RURAL,UST_RURAL
+!   REAL,    DIMENSION( ims:ime, jms:jme ) :: GRDFLX_URB
+!   REAL,    DIMENSION( ims:ime, jms:jme ) :: QFX_URB,QSFC_URB,UMOM_URB,VMOM_URB
+   REAL,    DIMENSION( ims:ime, jms:jme ) :: HFX_URB,UMOM_URB,VMOM_URB
+   REAL,    DIMENSION( ims:ime, jms:jme ) :: QFX_URB
+!   REAL,    DIMENSION( ims:ime, jms:jme ) :: ALBEDO_URB,EMISS_URB,UMOM,VMOM,UST
+   REAL, DIMENSION(ims:ime,jms:jme) ::EMISS_URB
+   REAL, DIMENSION(ims:ime,jms:jme) :: RL_UP_URB
+   REAL, DIMENSION(ims:ime,jms:jme) ::RS_ABS_URB
+   REAL, DIMENSION(ims:ime,jms:jme) ::GRDFLX_URB
+   REAL :: SIGMA_SB,RL_UP_RURAL,RL_UP_TOT,RS_ABS_TOT,UMOM,VMOM
+   REAL :: r1,r2,r3
+   REAL :: CMR_URB, CHR_URB, CMC_URB, CHC_URB
+! ----------------------------------------------------------------------
+! DECLARATIONS END - urban
+! ----------------------------------------------------------------------
+!-------------------------------------------------
+! Noah-mosaic related variables are added to declaration  (danli)
+!-------------------------------------------------
+  
+  INTEGER, INTENT(IN) :: sf_surface_mosaic    
+  INTEGER, INTENT(IN) :: mosaic_cat, NLCAT
+  REAL, DIMENSION( ims:ime, NLCAT, jms:jme ), INTENT(IN) :: landusef 
+  REAL, DIMENSION( ims:ime, NLCAT, jms:jme ), INTENT(INOUT) ::landusef2 
+  INTEGER, DIMENSION( ims:ime, NLCAT, jms:jme ), INTENT(INOUT) :: mosaic_cat_index 
+
+  REAL, DIMENSION( ims:ime, 1:mosaic_cat, jms:jme ) , OPTIONAL, INTENT(INOUT)::   &
+        TSK_mosaic, QSFC_mosaic, CANWAT_mosaic, SNOW_mosaic,SNOWH_mosaic, SNOWC_mosaic 
+  REAL, DIMENSION( ims:ime, 1:mosaic_cat, jms:jme ) , OPTIONAL, INTENT(INOUT)::   &
+        ALBEDO_mosaic,ALBBCK_mosaic, EMISS_mosaic, EMBCK_mosaic, ZNT_mosaic, Z0_mosaic,   &
+        HFX_mosaic,QFX_mosaic, LH_mosaic, GRDFLX_mosaic,SNOTIME_mosaic    
+  REAL, DIMENSION( ims:ime, 1:num_soil_layers*mosaic_cat, jms:jme ), OPTIONAL, INTENT(INOUT)::   &
+        TSLB_mosaic,SMOIS_mosaic,SH2O_mosaic
+  REAL, DIMENSION( ims:ime, jms:jme ) :: TSK_mosaic_avg, QSFC_mosaic_avg, CANWAT_mosaic_avg,SNOW_mosaic_avg,SNOWH_mosaic_avg, &
+                                         SNOWC_mosaic_avg, HFX_mosaic_avg, QFX_mosaic_avg, LH_mosaic_avg, GRDFLX_mosaic_avg,  &
+                                         ALBEDO_mosaic_avg, ALBBCK_mosaic_avg, EMISS_mosaic_avg, EMBCK_mosaic_avg,            &
+                                         ZNT_mosaic_avg, Z0_mosaic_avg, SNOTIME_mosaic_avg, FAREA_mosaic_avg  
+  REAL, DIMENSION( ims:ime, 1:num_soil_layers, jms:jme )                     ::   &
+        TSLB_mosaic_avg,SMOIS_mosaic_avg,SH2O_mosaic_avg
+  
+  REAL, DIMENSION( ims:ime, 1:mosaic_cat, jms:jme ) , OPTIONAL, INTENT(INOUT)::   &
+        TR_URB2D_mosaic, TB_URB2D_mosaic, TG_URB2D_mosaic, TC_URB2D_mosaic,QC_URB2D_mosaic, UC_URB2D_mosaic, &
+        SH_URB2D_mosaic,LH_URB2D_mosaic,G_URB2D_mosaic,RN_URB2D_mosaic,TS_URB2D_mosaic, TS_RUL2D_mosaic  
+                  
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_roof_layers*mosaic_cat, jms:jme ), INTENT(INOUT) :: TRL_URB3D_mosaic
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_wall_layers*mosaic_cat, jms:jme ), INTENT(INOUT) :: TBL_URB3D_mosaic
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_road_layers*mosaic_cat, jms:jme ), INTENT(INOUT) :: TGL_URB3D_mosaic
+
+  INTEGER, DIMENSION( ims:ime, jms:jme ) ::    IVGTYP_dominant
+  INTEGER ::  mosaic_i, URBAN_METHOD, zo_avg_option
+  REAL :: FAREA
+  LOGICAL :: IPRINT_mosaic, Noah_call
+!-------------------------------------------------
+! Noah-mosaic related variables declaration end (danli)
+!-------------------------------------------------
+
+  REAL, PARAMETER  :: CAPA=R_D/CP
+  REAL :: APELM,APES,SFCTH2,PSFC
+  real, intent(in) :: xice_threshold
+  character(len=80) :: message_text
+!
+! MEK MAY 2007
+      FDTLIW=DT/ROWLIW
+! MEK JUL2007
+      FDTW=DT/(XLV*RHOWATER)
+! debug printout
+      IPRINT=.false.
+      IPRINT_mosaic=.false.
+!      SLOPETYP=2
+      SLOPETYP=1
+!      SHDMIN=0.00
+
+      NSOIL=num_soil_layers
+
+     DO NS=1,NSOIL
+     SLDPTH(NS)=DZS(NS)
+     ENDDO
+
+     DO J=jts,jte
+
+      IF(ITIMESTEP.EQ.1)THEN
+        DO 50 I=its,ite
+!*** initialize soil conditions for IHOP 31 May case
+!         IF((XLAND(I,J)-1.5) < 0.)THEN
+!            if (I==108.and.j==85) then
+!                  DO NS=1,NSOIL
+!                      SMOIS(I,NS,J)=0.10
+!                      SH2O(I,NS,J)=0.10
+!                  enddo
+!             endif
+!         ENDIF
+
+!*** SET ZERO-VALUE FOR SOME OUTPUT DIAGNOSTIC ARRAYS
+          IF((XLAND(I,J)-1.5).GE.0.)THEN
+! check sea-ice point
+#if 0
+            IF( XICE(I,J).GE. XICE_THRESHOLD .and. IPRINT ) PRINT*, ' sea-ice at water point, I=',I,'J=',J
+#endif
+!***   Open Water Case
+            SMSTAV(I,J)=1.0
+            SMSTOT(I,J)=1.0
+            DO NS=1,NSOIL
+              SMOIS(I,NS,J)=1.0
+              TSLB(I,NS,J)=273.16                                          !STEMP
+              SMCREL(I,NS,J)=1.0
+            ENDDO
+          ELSE
+            IF ( XICE(I,J) .GE. XICE_THRESHOLD ) THEN
+!***        SEA-ICE CASE
+              SMSTAV(I,J)=1.0
+              SMSTOT(I,J)=1.0
+              DO NS=1,NSOIL
+                SMOIS(I,NS,J)=1.0
+                SMCREL(I,NS,J)=1.0
+              ENDDO
+            ENDIF
+          ENDIF
+!
+   50   CONTINUE
+      ENDIF                                                               ! end of initialization over ocean
+
+!-----------------------------------------------------------------------
+         DO 100 I=its,ite
+      
+         IF (((XLAND(I,J)-1.5).LT.0.) .AND. (XICE(I,J) < XICE_THRESHOLD) ) THEN
+               
+               IVGTYP_dominant(I,J)=IVGTYP(I,J)                                   ! save this
+      
+            ! INITIALIZE THE AREA-AVERAGED FLUXES 
+               
+                 TSK_mosaic_avg(i,j)= 0                              ! from 3D to 2D
+                 QSFC_mosaic_avg(i,j)= 0
+                 CANWAT_mosaic_avg(i,j)= 0
+                 SNOW_mosaic_avg(i,j)= 0
+                 SNOWH_mosaic_avg(i,j)= 0
+                 SNOWC_mosaic_avg(i,j)= 0
+            
+                          DO NS=1,NSOIL
+            
+                     TSLB_mosaic_avg(i,NS,j)=0
+                     SMOIS_mosaic_avg(i,NS,j)=0
+                     SH2O_mosaic_avg(i,NS,j)=0
+            
+                         ENDDO
+            
+                 HFX_mosaic_avg(i,j)= 0
+                 QFX_mosaic_avg(i,j)= 0  
+                 LH_mosaic_avg(i,j)=  0 
+                 GRDFLX_mosaic_avg(i,j)= 0
+                 ALBEDO_mosaic_avg(i,j)=0
+                 ALBBCK_mosaic_avg(i,j)=0
+                 EMISS_mosaic_avg(i,j)=0
+                 EMBCK_mosaic_avg(i,j)=0
+                 ZNT_mosaic_avg(i,j)=0
+                 Z0_mosaic_avg(i,j)=0  
+                 FAREA_mosaic_avg(i,j)=0  
+            
+            ! add a new loop for the mosaic_cat
+            
+               DO mosaic_i = mosaic_cat, 1, -1
+               
+            !   if (mosaic_cat_index(I,mosaic_i,J) .EQ. 16 ) then
+            !   PRINT*, 'you still have water tiles at','i=',i,'j=',j, 'mosaic_i',mosaic_i
+            !   PRINT*, 'xland',xland(i,j),'xice',xice(i,j)
+            !   endif
+               
+               IVGTYP(I,J)=mosaic_cat_index(I,mosaic_i,J)                         ! replace it with the mosaic one          
+               TSK(I,J)=TSK_mosaic(I,mosaic_i,J)                                  ! from 3D to 2D
+               QSFC(i,j)=QSFC_mosaic(I,mosaic_i,J)
+               CANWAT(i,j)=CANWAT_mosaic(i,mosaic_i,j) 
+               SNOW(i,j)=SNOW_mosaic(i,mosaic_i,j) 
+               SNOWH(i,j)=SNOWH_mosaic(i,mosaic_i,j)  
+               SNOWC(i,j)=SNOWC_mosaic(i,mosaic_i,j)
+            
+                ALBEDO(i,j) = ALBEDO_mosaic(i,mosaic_i,j)
+                ALBBCK(i,j)= ALBBCK_mosaic(i,mosaic_i,j) 
+                EMISS(i,j)= EMISS_mosaic(i,mosaic_i,j) 
+                EMBCK(i,j)= EMBCK_mosaic(i,mosaic_i,j) 
+                ZNT(i,j)= ZNT_mosaic(i,mosaic_i,j) 
+                Z0(i,j)= Z0_mosaic(i,mosaic_i,j)    
+            
+                 SNOTIME(i,j)= SNOTIME_mosaic(i,mosaic_i,j)          
+              
+                          DO NS=1,NSOIL
+            
+                     TSLB(i,NS,j)=TSLB_mosaic(i,NSOIL*(mosaic_i-1)+NS,j)
+                     SMOIS(i,NS,j)=SMOIS_mosaic(i,NSOIL*(mosaic_i-1)+NS,j)
+                     SH2O(i,NS,j)=SH2O_mosaic(i,NSOIL*(mosaic_i-1)+NS,j)
+            
+                          ENDDO
+            
+                       IF(IPRINT_mosaic) THEN
+            
+                   print*, 'BEFORE SFLX, in Mosaic Noahdrv.F'
+                   print*, 'mosaic_cat', mosaic_cat, 'IVGTYP',IVGTYP(i,j),'IVGTYP_dominant',IVGTYP_dominant(i,j), 'TSK',TSK(i,j),'HFX',HFX(i,j), 'QSFC', QSFC(i,j),   &
+                   'CANWAT', CANWAT(i,j), 'SNOW',SNOW(i,j), 'ALBEDO',ALBEDO(i,j), 'TSLB',TSLB(i,1,j),'CHS',CHS(i,j),'ZNT',ZNT(i,j),'landusef2',landusef2(i,mosaic_i,j)
+            
+                       ENDIF
+            
+            !-----------------------------------------------------------------------
+            ! insert the NOAH model here for the non-urban one and the urban one  DANLI
+            !-----------------------------------------------------------------------
+            
+      ! surface pressure
+              PSFC=P8w3D(i,1,j)
+      ! pressure in middle of lowest layer
+              SFCPRS=(P8W3D(I,KTS+1,j)+P8W3D(i,KTS,j))*0.5
+      ! convert from mixing ratio to specific humidity
+               Q2K=QV3D(i,1,j)/(1.0+QV3D(i,1,j))
+      !
+      !         Q2SAT=QGH(I,j)
+               Q2SAT=QGH(I,J)/(1.0+QGH(I,J))        ! Q2SAT is sp humidity
+      ! add check on myj=.true.
+      !        IF((Q2K.GE.Q2SAT*TRESH).AND.Q2K.LT.QZ0(I,J))THEN
+              IF((myj).AND.(Q2K.GE.Q2SAT*TRESH).AND.Q2K.LT.QZ0(I,J))THEN
+                SATFLG=0.
+                CHKLOWQ(I,J)=0.
+              ELSE
+                SATFLG=1.0
+                CHKLOWQ(I,J)=1.
+              ENDIF
+      
+              SFCTMP=T3D(i,1,j)
+              ZLVL=0.5*DZ8W(i,1,j)
+      
+      !        TH2=SFCTMP+(0.0097545*ZLVL)
+      ! calculate SFCTH2 via Exner function vs lapse-rate (above)
+               APES=(1.E5/PSFC)**CAPA
+               APELM=(1.E5/SFCPRS)**CAPA
+               SFCTH2=SFCTMP*APELM
+               TH2=SFCTH2/APES
+      !
+               EMISSI = EMISS(I,J)
+               LWDN=GLW(I,J)*EMISSI
+      ! SOLDN is total incoming solar
+              SOLDN=SWDOWN(I,J)
+      ! GSW is net downward solar
+      !        SOLNET=GSW(I,J)
+      ! use mid-day albedo to determine net downward solar (no solar zenith angle correction)
+              SOLNET=SOLDN*(1.-ALBEDO(I,J))
+              PRCP=RAINBL(i,j)/DT
+              VEGTYP=IVGTYP(I,J)
+              SOILTYP=ISLTYP(I,J)
+              SHDFAC=VEGFRA(I,J)/100.
+              T1=TSK(I,J)
+              CHK=CHS(I,J)
+              SHMIN=SHDMIN(I,J)/100. !NEW
+              SHMAX=SHDMAX(I,J)/100. !NEW
+      ! convert snow water equivalent from mm to meter
+              SNEQV=SNOW(I,J)*0.001
+      ! snow depth in meters
+              SNOWHK=SNOWH(I,J)
+              SNCOVR=SNOWC(I,J)
+      
+      ! if "SR" present, set frac of frozen precip ("FFROZP") = snow-ratio ("SR", range:0-1)
+      ! SR from e.g. Ferrier microphysics
+      ! otherwise define from 1st atmos level temperature
+             IF(FRPCPN) THEN
+                FFROZP=SR(I,J)
+              ELSE
+                IF (SFCTMP <=  273.15) THEN
+                  FFROZP = 1.0
+      	  ELSE
+      	    FFROZP = 0.0
+      	  ENDIF
+              ENDIF
+      !***
+              IF((XLAND(I,J)-1.5).GE.0.)THEN                                  ! begining of land/sea if block
+      ! Open water points
+                TSK_RURAL(I,J)=TSK(I,J)
+                HFX_RURAL(I,J)=HFX(I,J)
+                QFX_RURAL(I,J)=QFX(I,J)
+                LH_RURAL(I,J)=LH(I,J)
+                EMISS_RURAL(I,J)=EMISS(I,J)
+                GRDFLX_RURAL(I,J)=GRDFLX(I,J)
+              ELSE
+      ! Land or sea-ice case
+      
+                IF (XICE(I,J) >= XICE_THRESHOLD) THEN
+                   ! Sea-ice point
+                   ICE = 1
+                ELSE IF ( VEGTYP == ISICE ) THEN
+                   ! Land-ice point
+                   ICE = -1
+                ELSE
+                   ! Neither sea ice or land ice.
+                   ICE=0
+                ENDIF
+                DQSDT2=Q2SAT*A23M4/(SFCTMP-A4)**2
+      
+                IF(SNOW(I,J).GT.0.0)THEN
+      ! snow on surface (use ice saturation properties)
+                  SFCTSNO=SFCTMP
+                  E2SAT=611.2*EXP(6174.*(1./273.15 - 1./SFCTSNO))
+                  Q2SATI=0.622*E2SAT/(SFCPRS-E2SAT)
+                  Q2SATI=Q2SATI/(1.0+Q2SATI)    ! spec. hum.
+                  IF (T1 .GT. 273.14) THEN
+      ! warm ground temps, weight the saturation between ice and water according to SNOWC
+                    Q2SAT=Q2SAT*(1.-SNOWC(I,J)) + Q2SATI*SNOWC(I,J)
+                    DQSDT2=DQSDT2*(1.-SNOWC(I,J)) + Q2SATI*6174./(SFCTSNO**2)*SNOWC(I,J)
+                  ELSE
+      ! cold ground temps, use ice saturation only
+                    Q2SAT=Q2SATI
+                    DQSDT2=Q2SATI*6174./(SFCTSNO**2)
+                  ENDIF
+      ! for snow cover fraction at 0 C, ground temp will not change, so DQSDT2 effectively zero
+                  IF(T1 .GT. 273. .AND. SNOWC(I,J) .GT. 0.)DQSDT2=DQSDT2*(1.-SNOWC(I,J))
+                ENDIF
+      
+               IF(ICE.EQ.1)THEN
+              ! Sea-ice point has deep-level temperature of -2 C
+              TBOT=271.16
+               ELSE
+              ! Land-ice or land points have the usual deep-soil temperature.
+              TBOT=TMN(I,J)
+              ENDIF
+
+      
+                IF(VEGTYP.EQ.25) SHDFAC=0.0000
+                IF(VEGTYP.EQ.26) SHDFAC=0.0000
+                IF(VEGTYP.EQ.27) SHDFAC=0.0000
+                IF(SOILTYP.EQ.14.AND.XICE(I,J).EQ.0.)THEN
+#if 0
+               IF(IPRINT)PRINT*,' SOIL TYPE FOUND TO BE WATER AT A LAND-POINT'
+               IF(IPRINT)PRINT*,i,j,'RESET SOIL in surfce.F'
+#endif
+                  SOILTYP=7
+                ENDIF
+                SNOALB1 = SNOALB(I,J)
+                CMC=CANWAT(I,J)
+      
+      !-------------------------------------------
+      !*** convert snow depth from mm to meter
+      !
+      !          IF(RDMAXALB) THEN
+      !           SNOALB=ALBMAX(I,J)*0.01
+      !         ELSE
+      !           SNOALB=MAXALB(IVGTPK)*0.01
+      !         ENDIF
+      
+      !        SNOALB1=0.80
+      !        SHMIN=0.00
+              ALBBRD=ALBBCK(I,J)
+              Z0BRD=Z0(I,J)
+              EMBRD=EMBCK(I,J)
+              SNOTIME1 = SNOTIME(I,J)
+              RIBB=RIB(I,J)
+      !FEI: temporaray arrays above need to be changed later by using SI
+      
+                DO 70 NS=1,NSOIL
+                  SMC(NS)=SMOIS(I,NS,J)
+                  STC(NS)=TSLB(I,NS,J)                                          !STEMP
+                  SWC(NS)=SH2O(I,NS,J)
+                70 CONTINUE
+      !
+                if ( (SNEQV.ne.0..AND.SNOWHK.eq.0.).or.(SNOWHK.le.SNEQV) )THEN
+                  SNOWHK= 5.*SNEQV
+                endif
+      !
+      
+      !Fei: urban. for urban surface, if calling UCM, redefine the natural surface in cities as
+      ! the "NATURAL" category in the VEGPARM.TBL
+      	
+      	!   IF(SF_URBAN_PHYSICS == 1.OR. SF_URBAN_PHYSICS==2.OR.SF_URBAN_PHYSICS==3 ) THEN
+                       
+      
+           !           IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+           !            IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+           !	 VEGTYP = NATURAL
+           !            SHDFAC = SHDTBL(NATURAL)
+           !            ALBEDOK =0.2         !  0.2
+           !            ALBBRD  =0.2         !0.2
+           !            EMISSI = 0.98                                 !for VEGTYP=5
+           !	 IF ( FRC_URB2D(I,J) < 0.99 ) THEN
+          !               if(sf_urban_physics.eq.1)then
+          !       T1= ( TSK(I,J) -FRC_URB2D(I,J) * TS_URB2D (I,J) )/ (1-FRC_URB2D(I,J))
+          !               elseif((sf_urban_physics.eq.2).OR.(sf_urban_physics.eq.3))then
+          !            r1= (tsk(i,j)**4.)
+          !            r2= frc_urb2d(i,j)*(ts_urb2d(i,j)**4.)
+          !            r3= (1.-frc_urb2d(i,j))
+         !             t1= ((r1-r2)/r3)**.25
+         !                endif
+         !	         ELSE
+         !		 T1 = TSK(I,J)
+         !              ENDIF
+         !             ENDIF
+          !       ELSE
+           !            IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+          !              IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+           !             VEGTYP = ISURBAN
+           !      	 ENDIF
+           !      ENDIF
+      
+            Noah_call=.TRUE.
+      
+            If ( SF_URBAN_PHYSICS == 0 ) THEN   ! ONLY NOAH
+      
+                 IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                       IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+                       Noah_call = .TRUE.                 
+                       VEGTYP = ISURBAN
+                 ENDIF
+      
+            ENDIF
+            
+            IF(SF_URBAN_PHYSICS == 1) THEN
+      
+                 IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                       IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN   
+              	
+                       Noah_call = .TRUE.                       
+              	       VEGTYP = NATURAL                                              
+                       SHDFAC = SHDTBL(NATURAL)
+                       ALBEDOK =0.2         !  0.2
+                       ALBBRD  =0.2         !  0.2
+                       EMISSI = 0.98        !  for VEGTYP=5       
+                       
+      		      T1= TS_RUL2D_mosaic(I,mosaic_i,J)
+                       
+                 ENDIF
+      
+            ENDIF
+
+!===Yang, 2014/10/08, hydrological processes for urban vegetation in single layer UCM===  Commented out PCC
+!           AOASIS = 1.0
+!           USOIL = 1
+!           DSOIL = 2
+!           IRIOPTION=IRI_SCHEME
+!           OMG= OMG_URB2D(I,J)   
+!           tloc=mod(int(OMG/3.14159*180./15.+12.+0.5 ),24)
+!           if (tloc.lt.0) tloc=tloc+24
+!           if (tloc==0) tloc=24
+!           CALL cal_mon_day(julian,julyr,jmonth,jday) 
+!	  IF(SF_URBAN_PHYSICS == 1) THEN
+!           IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+!                IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+!            AOASIS = oasis  ! urban oasis effect
+!                   IF (IRIOPTION ==1) THEN
+!                   IF (tloc==21 .or. tloc==22) THEN  !irrigation on vegetaion in urban area, MAY-SEP, 9-10pm
+!                   IF (jmonth==5 .or. jmonth==6 .or. jmonth==7 .or. jmonth==8 .or. jmonth==9) THEN
+!                      IF (SMC(USOIL) .LT. SMCREF) SMC(USOIL)= REFSMC(ISLTYP(I,J))
+!                      IF (SMC(DSOIL) .LT. SMCREF) SMC(DSOIL)= REFSMC(ISLTYP(I,J))
+!                   ENDIF
+!                   ENDIF
+!                   ENDIF
+!                ENDIF
+!           ENDIF
+
+!	  IF(SF_URBAN_PHYSICS == 2 .or. SF_URBAN_PHYSICS == 3) THEN
+!          IF(AOASIS > 1.0) THEN
+!          CALL wrf_error_fatal('Urban oasis option is for SF_URBAN_PHYSICS == 1 only')
+!          ENDIF
+!          IF(IRIOPTION == 1) THEN
+!          CALL wrf_error_fatal('Urban irrigation option is for SF_URBAN_PHYSICS == 1 only')
+!          ENDIF
+!          ENDIF
+            
+            IF( SF_URBAN_PHYSICS==2.OR.SF_URBAN_PHYSICS==3 ) THEN
+!             print*, 'MOSAIC is not designed to work with SF_URBAN_PHYSICS=2 or SF_URBAN_PHYSICS=3'
+            ENDIF
+      
+         IF (Noah_call) THEN
+#if 0
+                IF(IPRINT) THEN
+      !
+             print*, 'BEFORE SFLX, in Mosaic Noahlsm_driver'
+             print*, 'ICE', ICE, 'DT',DT, 'ZLVL',ZLVL, 'NSOIL', NSOIL,   &
+             'SLDPTH', SLDPTH, 'LOCAL',LOCAL, 'LUTYPE',&
+              LUTYPE, 'SLTYPE',SLTYPE, 'LWDN',LWDN, 'SOLDN',SOLDN,      &
+              'SFCPRS',SFCPRS, 'PRCP',PRCP,'SFCTMP',SFCTMP,'Q2K',Q2K,   &
+               'TH2',TH2,'Q2SAT',Q2SAT,'DQSDT2',DQSDT2,'VEGTYP', VEGTYP,&
+               'SOILTYP',SOILTYP, 'SLOPETYP',SLOPETYP, 'SHDFAC',SHDFAC,&
+               'SHMIN',SHMIN, 'ALBBRD',ALBBRD,'SNOALB1',SNOALB1,'TBOT',&
+                TBOT, 'Z0BRD',Z0BRD, 'Z0K',Z0K, 'CMC',CMC, 'T1',T1,'STC',&
+                STC, 'SMC',SMC, 'SWC',SWC,'SNOWHK',SNOWHK,'SNEQV',SNEQV,&
+                'ALBEDOK',ALBEDOK,'CHK',CHK,'ETA',ETA,'SHEAT',SHEAT,      &
+                'ETA_KINEMATIC',ETA_KINEMATIC, 'FDOWN',FDOWN,'EC',EC,   &
+                'EDIR',EDIR,'ET',ET,'ETT',ETT,'ESNOW',ESNOW,'DRIP',DRIP,&
+                'DEW',DEW,'BETA',BETA,'ETP',ETP,'SSOIL',SSOIL,'FLX1',FLX1,&
+                'FLX2',FLX2,'FLX3',FLX3,'SNOMLT',SNOMLT,'SNCOVR',SNCOVR,&
+                'RUNOFF1',RUNOFF1,'RUNOFF2',RUNOFF2,'RUNOFF3',RUNOFF3, &
+                'RC',RC, 'PC',PC,'RSMIN',RSMIN,'XLAI',XLAI,'RCS',RCS,  &
+                'RCT',RCT,'RCQ',RCQ,'RCSOIL',RCSOIL,'SOILW',SOILW,     &
+                'SOILM',SOILM,'Q1',Q1,'SMCWLT',SMCWLT,'SMCDRY',SMCDRY,&
+                'SMCREF',SMCREF,'SMCMAX',SMCMAX,'NROOT',NROOT
+                 endif
+#endif
+      
+                IF (rdlai2d) THEN
+                   xlai = lai(i,j)
+                endif
+   
+      
+             CALL SFLX (FFROZP, ICE, ISURBAN, DT,ZLVL,NSOIL,SLDPTH,       &    !C
+                       LOCAL,                                            &    !L
+                       LUTYPE, SLTYPE,                                   &    !CL
+                       LWDN,SOLDN,SOLNET,SFCPRS,PRCP,SFCTMP,Q2K,DUMMY,   &    !F
+                       DUMMY,DUMMY, DUMMY,                               &    !F PRCPRAIN not used
+                       TH2,Q2SAT,DQSDT2,                                 &    !I
+                       VEGTYP,SOILTYP,SLOPETYP,SHDFAC,SHMIN,SHMAX,       &    !I
+                       ALBBRD, SNOALB1,TBOT, Z0BRD, Z0K, EMISSI, EMBRD,  &    !S
+                       CMC,T1,STC,SMC,SWC,SNOWHK,SNEQV,ALBEDOK,CHK,dummy,&    !H
+                       ETA,SHEAT, ETA_KINEMATIC,FDOWN,                   &    !O
+                       EC,EDIR,ET,ETT,ESNOW,DRIP,DEW,                    &    !O
+                       BETA,ETP,SSOIL,                                   &    !O
+                       FLX1,FLX2,FLX3,                                   &    !O
+      		       SNOMLT,SNCOVR,                                    &    !O
+                       RUNOFF1,RUNOFF2,RUNOFF3,                          &    !O
+                       RC,PC,RSMIN,XLAI,RCS,RCT,RCQ,RCSOIL,              &    !O
+                       SOILW,SOILM,Q1,SMAV,                              &    !D
+                       RDLAI2D,USEMONALB,                                &
+                       SNOTIME1,                                         &
+                       RIBB,                                             &
+                       SMCWLT,SMCDRY,SMCREF,SMCMAX,NROOT)
+      
+ 
+             lai(i,j) = xlai
+      
+#if 0
+                IF(IPRINT) THEN
+      
+             print*, 'AFTER SFLX, in Mosaic Noahlsm_driver'
+             print*, 'ICE', ICE, 'DT',DT, 'ZLVL',ZLVL, 'NSOIL', NSOIL,   &
+             'SLDPTH', SLDPTH, 'LOCAL',LOCAL, 'LUTYPE',&
+              LUTYPE, 'SLTYPE',SLTYPE, 'LWDN',LWDN, 'SOLDN',SOLDN,      &
+              'SFCPRS',SFCPRS, 'PRCP',PRCP,'SFCTMP',SFCTMP,'Q2K',Q2K,   &
+               'TH2',TH2,'Q2SAT',Q2SAT,'DQSDT2',DQSDT2,'VEGTYP', VEGTYP,&
+                'SOILTYP',SOILTYP, 'SLOPETYP',SLOPETYP, 'SHDFAC',SHDFAC,&
+               'SHDMIN',SHMIN, 'ALBBRD',ALBBRD,'SNOALB',SNOALB1,'TBOT',&
+                TBOT, 'Z0BRD',Z0BRD, 'Z0K',Z0K, 'CMC',CMC, 'T1',T1,'STC',&
+                STC, 'SMC',SMC, 'SWc',SWC,'SNOWHK',SNOWHK,'SNEQV',SNEQV,&
+                'ALBEDOK',ALBEDOK,'CHK',CHK,'ETA',ETA,'SHEAT',SHEAT,      &
+                'ETA_KINEMATIC',ETA_KINEMATIC, 'FDOWN',FDOWN,'EC',EC,   &
+                'EDIR',EDIR,'ET',ET,'ETT',ETT,'ESNOW',ESNOW,'DRIP',DRIP,&
+                'DEW',DEW,'BETA',BETA,'ETP',ETP,'SSOIL',SSOIL,'FLX1',FLX1,&
+                'FLX2',FLX2,'FLX3',FLX3,'SNOMLT',SNOMLT,'SNCOVR',SNCOVR,&
+                'RUNOFF1',RUNOFF1,'RUNOFF2',RUNOFF2,'RUNOFF3',RUNOFF3, &
+                'RC',RC, 'PC',PC,'RSMIN',RSMIN,'XLAI',XLAI,'RCS',RCS,  &
+                'RCT',RCT,'RCQ',RCQ,'RCSOIL',RCSOIL,'SOILW',SOILW,     &
+                'SOILM',SOILM,'Q1',Q1,'SMCWLT',SMCWLT,'SMCDRY',SMCDRY,&
+                'SMCREF',SMCREF,'SMCMAX',SMCMAX,'NROOT',NROOT
+                 endif
+#endif
+      
+      !***  UPDATE STATE VARIABLES
+                CANWAT(I,J)=CMC
+                SNOW(I,J)=SNEQV*1000.
+      !          SNOWH(I,J)=SNOWHK*1000.
+                SNOWH(I,J)=SNOWHK                   ! SNOWHK in meters
+                ALBEDO(I,J)=ALBEDOK
+                ALB_RURAL(I,J)=ALBEDOK
+                ALBBCK(I,J)=ALBBRD
+                Z0(I,J)=Z0BRD
+                EMISS(I,J) = EMISSI
+                EMISS_RURAL(I,J) = EMISSI
+      !MEK Nov2006 turn off
+      !ZNT(I,J)=Z0K          
+                TSK(I,J)=T1
+                TSK_RURAL(I,J)=T1
+                HFX(I,J)=SHEAT
+                HFX_RURAL(I,J)=SHEAT
+      ! MEk Jul07 add potential evap accum
+              POTEVP(I,J)=POTEVP(I,J)+ETP*FDTW
+                QFX(I,J)=ETA_KINEMATIC
+                QFX_RURAL(I,J)=ETA_KINEMATIC
+      
+     
+                LH(I,J)=ETA
+                LH_RURAL(I,J)=ETA
+                GRDFLX(I,J)=SSOIL
+                GRDFLX_RURAL(I,J)=SSOIL
+                SNOWC(I,J)=SNCOVR
+                CHS2(I,J)=CQS2(I,J)
+                SNOTIME(I,J) = SNOTIME1
+      !      prevent diagnostic ground q (q1) from being greater than qsat(tsk)
+      !      as happens over snow cover where the cqs2 value also becomes irrelevant
+      !      by setting cqs2=chs in this situation the 2m q should become just qv(k=1)
+                IF (Q1 .GT. QSFC(I,J)) THEN
+                  CQS2(I,J) = CHS(I,J)
+                ENDIF
+      !          QSFC(I,J)=Q1
+      ! Convert QSFC back to mixing ratio
+                 QSFC(I,J)= Q1/(1.0-Q1)
+      !
+                 QSFC_RURAL(I,J)= Q1/(1.0-Q1)
+      ! Calculate momentum flux from rural surface for use with multi-layer UCM (Martilli et al. 2002)
+      
+                DO 81 NS=1,NSOIL
+                 SMOIS(I,NS,J)=SMC(NS)
+                 TSLB(I,NS,J)=STC(NS)                                        !  STEMP
+                 SH2O(I,NS,J)=SWC(NS)
+         81     CONTINUE
+      !       ENDIF
+      
+           !
+           ! Residual of surface energy balance equation terms
+           !
+      
+           
+               noahres(i,j) = ( solnet + lwdn ) - sheat + ssoil - eta &
+                    - ( emissi * STBOLT * (t1**4) ) - flx1 - flx2 - flx3
+           
+      
+               ENDIF   !ENDIF FOR Noah_call
+               
+              IF (SF_URBAN_PHYSICS == 1 ) THEN                                              ! Beginning of UCM CALL if block
+      !--------------------------------------
+      ! URBAN CANOPY MODEL START - urban
+      !--------------------------------------
+      ! Input variables lsm --> urban
+      
+                IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                    IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33 ) THEN            
+      
+                !  UTYPE_URB = UTYPE_URB2D(I,J) !urban type (low, high or industrial)
+                !  this need to be changed in the mosaic danli
+      
+                IF(IVGTYP(I,J)==ISURBAN) UTYPE_URB=2
+                IF(IVGTYP(I,J)==31) UTYPE_URB=1
+                IF(IVGTYP(I,J)==32) UTYPE_URB=2
+                IF(IVGTYP(I,J)==33) UTYPE_URB=3
+                        
+                IF(UTYPE_URB==1) FRC_URB2D(I,J)=0.5
+                IF(UTYPE_URB==2) FRC_URB2D(I,J)=0.9
+                IF(UTYPE_URB==3) FRC_URB2D(I,J)=0.95
+      
+                  TA_URB    = SFCTMP           ! [K]
+                  QA_URB    = Q2K              ! [kg/kg]
+                  UA_URB    = SQRT(U_PHY(I,1,J)**2.+V_PHY(I,1,J)**2.)
+                  U1_URB    = U_PHY(I,1,J)
+                  V1_URB    = V_PHY(I,1,J)
+                  IF(UA_URB < 1.) UA_URB=1.    ! [m/s]
+                  SSG_URB   = SOLDN            ! [W/m/m]
+                  SSGD_URB  = 0.8*SOLDN        ! [W/m/m]
+                  SSGQ_URB  = SSG_URB-SSGD_URB ! [W/m/m]
+                  LLG_URB   = GLW(I,J)         ! [W/m/m]
+                  RAIN_URB  = RAINBL(I,J)      ! [mm]
+                  RHOO_URB  = SFCPRS / (287.04 * SFCTMP * (1.0+ 0.61 * Q2K)) ![kg/m/m/m]
+                  ZA_URB    = ZLVL             ! [m]
+                  DELT_URB  = DT               ! [sec]
+                  XLAT_URB  = XLAT_URB2D(I,J)  ! [deg]
+                  COSZ_URB  = COSZ_URB2D(I,J)  !
+                  OMG_URB   = OMG_URB2D(I,J)   !
+                  ZNT_URB   = ZNT(I,J)
+      
+                  LSOLAR_URB = .FALSE.
+                  
+      ! mosaic 3D to 2D
+      
+         TR_URB2D(I,J)=TR_URB2D_mosaic(I,mosaic_i,J)                         ! replace it with the mosaic one          
+         TB_URB2D(I,J)=TB_URB2D_mosaic(I,mosaic_i,J)                         ! replace it with the mosaic one          
+         TG_URB2D(I,J)=TG_URB2D_mosaic(I,mosaic_i,J)                         ! replace it with the mosaic one          
+         TC_URB2D(I,J)=TC_URB2D_mosaic(I,mosaic_i,J)                         ! replace it with the mosaic one          
+         QC_URB2D(I,J)=QC_URB2D_mosaic(I,mosaic_i,J)                         ! replace it with the mosaic one          
+         UC_URB2D(I,J)=UC_URB2D_mosaic(I,mosaic_i,J)                         ! replace it with the mosaic one          
+         TS_URB2D(I,J)=TS_URB2D_mosaic(I,mosaic_i,J)                         ! replace it with the mosaic one          
+      
+                  DO K = 1,num_roof_layers
+                    TRL_URB3D(I,K,J) = TRL_URB3D_mosaic(I,K+(mosaic_i-1)*num_roof_layers,J)
+                  END DO
+                  DO K = 1,num_wall_layers
+                    TBL_URB3D(I,K,J) = TBL_URB3D_mosaic(I,K+(mosaic_i-1)*num_roof_layers,J)
+                  END DO
+                  DO K = 1,num_road_layers
+                    TGL_URB3D(I,K,J) = TGL_URB3D_mosaic(I,K+(mosaic_i-1)*num_roof_layers,J)
+                  END DO
+      
+      ! mosaic 2D to 1D            
+      
+                  TR_URB = TR_URB2D(I,J)
+                  TB_URB = TB_URB2D(I,J)
+                  TG_URB = TG_URB2D(I,J)
+                  TC_URB = TC_URB2D(I,J)
+                  QC_URB = QC_URB2D(I,J)
+                  UC_URB = UC_URB2D(I,J)
+      
+                  DO K = 1,num_roof_layers
+                    TRL_URB(K) = TRL_URB3D(I,K,J)
+                  END DO
+                  DO K = 1,num_wall_layers
+                    TBL_URB(K) = TBL_URB3D(I,K,J)
+                  END DO
+                  DO K = 1,num_road_layers
+                    TGL_URB(K) = TGL_URB3D(I,K,J)
+                  END DO
+                  
+                      
+                  XXXR_URB = XXXR_URB2D(I,J)
+                  XXXB_URB = XXXB_URB2D(I,J)
+                  XXXG_URB = XXXG_URB2D(I,J)
+                  XXXC_URB = XXXC_URB2D(I,J)
+      !
+      !      Limits to avoid dividing by small number
+                  if (CHS(I,J) < 1.0E-02) then
+                     CHS(I,J)  = 1.0E-02
+                  endif
+                  if (CHS2(I,J) < 1.0E-02) then
+                     CHS2(I,J)  = 1.0E-02
+                  endif
+                  if (CQS2(I,J) < 1.0E-02) then
+                     CQS2(I,J)  = 1.0E-02
+                  endif
+      !
+                  CHS_URB  = CHS(I,J)
+                  CHS2_URB = CHS2(I,J)
+                  IF (PRESENT(CMR_SFCDIF)) THEN
+                     CMR_URB = CMR_SFCDIF(I,J)
+                     CHR_URB = CHR_SFCDIF(I,J)
+                     CMC_URB = CMC_SFCDIF(I,J)
+                     CHC_URB = CHC_SFCDIF(I,J)
+                  ENDIF
+      
+      !
+      ! Call urban                 
+                  CALL urban(LSOLAR_URB,                                      & ! I
+                             num_roof_layers,num_wall_layers,num_road_layers, & ! C
+                             DZR,DZB,DZG,                                     & ! C
+                             UTYPE_URB,TA_URB,QA_URB,UA_URB,U1_URB,V1_URB,SSG_URB, & ! I
+                             SSGD_URB,SSGQ_URB,LLG_URB,RAIN_URB,RHOO_URB,     & ! I
+                             ZA_URB,DECLIN_URB,COSZ_URB,OMG_URB,              & ! I
+                             XLAT_URB,DELT_URB,ZNT_URB,                       & ! I
+                             CHS_URB, CHS2_URB,                               & ! I
+                             TR_URB, TB_URB, TG_URB, TC_URB, QC_URB,UC_URB,   & ! H
+                             TRL_URB,TBL_URB,TGL_URB,                         & ! H
+                             XXXR_URB, XXXB_URB, XXXG_URB, XXXC_URB,          & ! H
+                             TS_URB,QS_URB,SH_URB,LH_URB,LH_KINEMATIC_URB,    & ! O
+                             SW_URB,ALB_URB,LW_URB,G_URB,RN_URB,PSIM_URB,PSIH_URB, & ! O
+                             GZ1OZ0_URB,                                      & !O
+                             CMR_URB, CHR_URB, CMC_URB, CHC_URB,              &
+                             U10_URB, V10_URB, TH2_URB, Q2_URB,               & ! O
+                             UST_URB)     
+      
+#if 0
+                IF(IPRINT) THEN
+      
+             print*, 'AFTER CALL URBAN Noah Mosaic'
+             print*,'num_roof_layers',num_roof_layers, 'num_wall_layers',  &
+              num_wall_layers,                                             &
+             'DZR',DZR,'DZB',DZB,'DZG',DZG,'UTYPE_URB',UTYPE_URB,'TA_URB', &
+              TA_URB,                                                      &
+              'QA_URB',QA_URB,'UA_URB',UA_URB,'U1_URB',U1_URB,'V1_URB',    &
+               V1_URB,                                                     &
+               'SSG_URB',SSG_URB,'SSGD_URB',SSGD_URB,'SSGQ_URB',SSGQ_URB,  &
+              'LLG_URB',LLG_URB,'RAIN_URB',RAIN_URB,'RHOO_URB',RHOO_URB,   &
+              'ZA_URB',ZA_URB, 'DECLIN_URB',DECLIN_URB,'COSZ_URB',COSZ_URB,&
+              'OMG_URB',OMG_URB,'XLAT_URB',XLAT_URB,'DELT_URB',DELT_URB,   &
+               'ZNT_URB',ZNT_URB,'TR_URB',TR_URB, 'TB_URB',TB_URB,'TG_URB',&
+               TG_URB,'TC_URB',TC_URB,'QC_URB',QC_URB,'TRL_URB',TRL_URB,   &
+                'TBL_URB',TBL_URB,'TGL_URB',TGL_URB,'XXXR_URB',XXXR_URB,   &
+               'XXXB_URB',XXXB_URB,'XXXG_URB',XXXG_URB,'XXXC_URB',XXXC_URB,&
+               'TS_URB',TS_URB,'QS_URB',QS_URB,'SH_URB',SH_URB,'LH_URB',   &
+               LH_URB, 'LH_KINEMATIC_URB',LH_KINEMATIC_URB,'SW_URB',SW_URB,&
+               'ALB_URB',ALB_URB,'LW_URB',LW_URB,'G_URB',G_URB,'RN_URB',   &
+                RN_URB, 'PSIM_URB',PSIM_URB,'PSIH_URB',PSIH_URB,          &
+               'U10_URB',U10_URB,'V10_URB',V10_URB,'TH2_URB',TH2_URB,      &
+                'Q2_URB',Q2_URB,'CHS_URB',CHS_URB,'CHS2_URB',CHS2_URB
+                 endif
+#endif
+      
+                  TS_URB2D(I,J) = TS_URB
+      
+                  ALBEDO(I,J) = FRC_URB2D(I,J)*ALB_URB+(1-FRC_URB2D(I,J))*ALBEDOK   ![-]
+                  HFX(I,J) = FRC_URB2D(I,J)*SH_URB+(1-FRC_URB2D(I,J))*SHEAT         ![W/m/m]
+                  QFX(I,J) = FRC_URB2D(I,J)*LH_KINEMATIC_URB &
+                           + (1-FRC_URB2D(I,J))*ETA_KINEMATIC                ![kg/m/m/s]
+                  LH(I,J) = FRC_URB2D(I,J)*LH_URB+(1-FRC_URB2D(I,J))*ETA            ![W/m/m]
+                  GRDFLX(I,J) = FRC_URB2D(I,J)*G_URB+(1-FRC_URB2D(I,J))*SSOIL       ![W/m/m]
+                  TSK(I,J) = FRC_URB2D(I,J)*TS_URB+(1-FRC_URB2D(I,J))*T1            ![K]
+                  Q1 = FRC_URB2D(I,J)*QS_URB+(1-FRC_URB2D(I,J))*Q1            ![-]
+      ! Convert QSFC back to mixing ratio
+                  QSFC(I,J)= Q1/(1.0-Q1)
+                  UST(I,J)= FRC_URB2D(I,J)*UST_URB+(1-FRC_URB2D(I,J))*UST(I,J)      ![m/s]
+                  ZNT(I,J)= EXP(FRC_URB2D(I,J)*ALOG(ZNT_URB)+(1-FRC_URB2D(I,J))* ALOG(ZNT(I,J)))   ! ADD BY DAN
+
+#if 0
+          IF(IPRINT)THEN
+      
+          print*, ' FRC_URB2D', FRC_URB2D,                        &
+          'ALB_URB',ALB_URB, 'ALBEDOK',ALBEDOK, &
+          'ALBEDO(I,J)',  ALBEDO(I,J),                  &
+          'SH_URB',SH_URB,'SHEAT',SHEAT, 'HFX(I,J)',HFX(I,J),  &
+          'LH_KINEMATIC_URB',LH_KINEMATIC_URB,'ETA_KINEMATIC',  &
+           ETA_KINEMATIC, 'QFX(I,J)',QFX(I,J),                  &
+          'LH_URB',LH_URB, 'ETA',ETA, 'LH(I,J)',LH(I,J),        &
+          'G_URB',G_URB,'SSOIL',SSOIL,'GRDFLX(I,J)', GRDFLX(I,J),&
+          'TS_URB',TS_URB,'T1',T1,'TSK(I,J)',TSK(I,J),          &
+          'QS_URB',QS_URB,'Q1',Q1,'QSFC(I,J)',QSFC(I,J)
+           endif
+#endif
+      
+      ! Renew Urban State Varialbes
+      
+                  TR_URB2D(I,J) = TR_URB
+                  TB_URB2D(I,J) = TB_URB
+                  TG_URB2D(I,J) = TG_URB
+                  TC_URB2D(I,J) = TC_URB
+                  QC_URB2D(I,J) = QC_URB
+                  UC_URB2D(I,J) = UC_URB
+      
+                  DO K = 1,num_roof_layers
+                    TRL_URB3D(I,K,J) = TRL_URB(K)
+                    
+                  END DO
+                  DO K = 1,num_wall_layers
+                    TBL_URB3D(I,K,J) = TBL_URB(K)
+                  END DO
+                  DO K = 1,num_road_layers
+                    TGL_URB3D(I,K,J) = TGL_URB(K)
+                  END DO
+
+                             
+                  XXXR_URB2D(I,J) = XXXR_URB
+                  XXXB_URB2D(I,J) = XXXB_URB
+                  XXXG_URB2D(I,J) = XXXG_URB
+                  XXXC_URB2D(I,J) = XXXC_URB
+      
+                  SH_URB2D(I,J)    = SH_URB
+                  LH_URB2D(I,J)    = LH_URB
+                  G_URB2D(I,J)     = G_URB
+                  RN_URB2D(I,J)    = RN_URB
+                  PSIM_URB2D(I,J)  = PSIM_URB
+                  PSIH_URB2D(I,J)  = PSIH_URB
+                  GZ1OZ0_URB2D(I,J)= GZ1OZ0_URB
+                  U10_URB2D(I,J)   = U10_URB
+                  V10_URB2D(I,J)   = V10_URB
+                  TH2_URB2D(I,J)   = TH2_URB
+                  Q2_URB2D(I,J)    = Q2_URB
+                  UST_URB2D(I,J)   = UST_URB
+                  AKMS_URB2D(I,J)  = KARMAN * UST_URB2D(I,J)/(GZ1OZ0_URB2D(I,J)-PSIM_URB2D(I,J))
+                  IF (PRESENT(CMR_SFCDIF)) THEN
+                     CMR_SFCDIF(I,J) = CMR_URB
+                     CHR_SFCDIF(I,J) = CHR_URB
+                     CMC_SFCDIF(I,J) = CMC_URB
+                     CHC_SFCDIF(I,J) = CHC_URB
+                  ENDIF
+                  
+                     ! 2D to 3D  mosaic danli
+      	    	              
+      	    	                       TR_URB2D_mosaic(I,mosaic_i,J)=TR_URB2D(I,J)                               
+      	    	    	               TB_URB2D_mosaic(I,mosaic_i,J)=TB_URB2D(I,J)                                   
+      	    	    	               TG_URB2D_mosaic(I,mosaic_i,J)=TG_URB2D(I,J)                                   
+      	    	    	               TC_URB2D_mosaic(I,mosaic_i,J)=TC_URB2D(I,J)                                  
+      	    	    	               QC_URB2D_mosaic(I,mosaic_i,J)=QC_URB2D(I,J)                                   
+      	    	    	               UC_URB2D_mosaic(I,mosaic_i,J)=UC_URB2D(I,J)                                   
+      	    	    	               TS_URB2D_mosaic(I,mosaic_i,J)=TS_URB2D(I,J)                                   
+      	    	    	               TS_RUL2D_mosaic(I,mosaic_i,J)=T1                                
+      	    	    	  	  
+      	    	    	  	              DO K = 1,num_roof_layers
+      	    	    	  	                TRL_URB3D_mosaic(I,K+(mosaic_i-1)*num_roof_layers,J)=TRL_URB3D(I,K,J) 
+      	    	    	  	              END DO
+      	    	    	  	              DO K = 1,num_wall_layers
+      	    	    	  	                TBL_URB3D_mosaic(I,K+(mosaic_i-1)*num_roof_layers,J)=TBL_URB3D(I,K,J) 
+      	    	    	  	              END DO
+      	    	    	  	              DO K = 1,num_road_layers
+      	    	    	  	                TGL_URB3D_mosaic(I,K+(mosaic_i-1)*num_roof_layers,J)=TGL_URB3D(I,K,J) 
+      	    	    	                        END DO
+      	    	    	            
+      	    	    	              SH_URB2D_mosaic(I,mosaic_i,J) = SH_URB2D(I,J)
+      	    	    	  	      LH_URB2D_mosaic(I,mosaic_i,J) = LH_URB2D(I,J)
+      	    	    	              G_URB2D_mosaic(I,mosaic_i,J)  = G_URB2D(I,J)
+                                    RN_URB2D_mosaic(I,mosaic_i,J) = RN_URB2D(I,J)
+                                    
+                END IF
+      
+               ENDIF                                   ! end of UCM CALL if block
+      !--------------------------------------
+      ! Urban Part End - urban
+      !--------------------------------------
+      
+      !***  DIAGNOSTICS
+                SMSTAV(I,J)=SOILW
+                SMSTOT(I,J)=SOILM*1000.
+                DO NS=1,NSOIL
+                SMCREL(I,NS,J)=SMAV(NS)
+                ENDDO
+      
+      !         Convert the water unit into mm
+                SFCRUNOFF(I,J)=SFCRUNOFF(I,J)+RUNOFF1*DT*1000.0
+                UDRUNOFF(I,J)=UDRUNOFF(I,J)+(RUNOFF2+RUNOFF3)*DT*1000.0
+      ! snow defined when fraction of frozen precip (FFROZP) > 0.5,
+                IF(FFROZP.GT.0.5)THEN
+                  ACSNOW(I,J)=ACSNOW(I,J)+PRCP*DT
+                ENDIF
+                IF(SNOW(I,J).GT.0.)THEN
+                  ACSNOM(I,J)=ACSNOM(I,J)+SNOMLT*1000.
+      ! accumulated snow-melt energy
+                  SNOPCX(I,J)=SNOPCX(I,J)-SNOMLT/FDTLIW
+                ENDIF
+      
+              ENDIF                                                           ! endif of land-sea test
+      
+      !-----------------------------------------------------------------------
+      ! Done with the Noah-UCM MOSAIC  DANLI
+      !-----------------------------------------------------------------------
+      
+                  TSK_mosaic(i,mosaic_i,j)=TSK(i,j)                           ! from 2D to 3D
+                  QSFC_mosaic(i,mosaic_i,j)=QSFC(i,j)
+                  CANWAT_mosaic(i,mosaic_i,j)=CANWAT(i,j) 
+                  SNOW_mosaic(i,mosaic_i,j)=SNOW(i,j) 
+                  SNOWH_mosaic(i,mosaic_i,j)=SNOWH(i,j)  
+                  SNOWC_mosaic(i,mosaic_i,j)=SNOWC(i,j) 
+      
+                  ALBEDO_mosaic(i,mosaic_i,j)=ALBEDO(i,j) 
+                  ALBBCK_mosaic(i,mosaic_i,j)=ALBBCK(i,j)  
+                  EMISS_mosaic(i,mosaic_i,j)=EMISS(i,j) 
+                  EMBCK_mosaic(i,mosaic_i,j)=EMBCK(i,j)  
+                  ZNT_mosaic(i,mosaic_i,j)=ZNT(i,j)  
+                  Z0_mosaic(i,mosaic_i,j)=Z0(i,j)    
+                                                                                       
+                  HFX_mosaic(i,mosaic_i,j)=HFX(i,j) 
+                  QFX_mosaic(i,mosaic_i,j)=QFX(i,j)  
+                  LH_mosaic(i,mosaic_i,j)=LH(i,j)  
+                  GRDFLX_mosaic(i,mosaic_i,j)=GRDFLX(i,j) 
+                  SNOTIME_mosaic(i,mosaic_i,j)=SNOTIME(i,j) 
+       
+                  DO NS=1,NSOIL
+        
+                  TSLB_mosaic(i,NSOIL*(mosaic_i-1)+NS,j)=TSLB(i,NS,j)
+                  SMOIS_mosaic(i,NSOIL*(mosaic_i-1)+NS,j)=SMOIS(i,NS,j)
+                  SH2O_mosaic(i,NSOIL*(mosaic_i-1)+NS,j)=SH2O(i,NS,j)  
+      
+                  ENDDO
+                  
+#if 0
+            IF(TSK_mosaic(i,mosaic_i,j) > 350 .OR. TSK_mosaic(i,mosaic_i,j) < 250 .OR. abs(HFX_mosaic(i,mosaic_i,j)) > 700 ) THEN
+                  print*, 'I', I, 'J', J, 'MOSAIC_I', MOSAIC_I
+                  print*, 'mosaic_cat_index',mosaic_cat_index(I,mosaic_i,J), 'landusef2',landusef2(i,mosaic_i,j)
+                  print*, 'TSK_mosaic', TSK_mosaic(i,mosaic_i,j), 'HFX_mosaic', HFX_mosaic(i,mosaic_i,j), &
+                          'LH_mosaic',LH_mosaic(i,mosaic_i,j),'GRDFLX_mosaic',GRDFLX_mosaic(i,mosaic_i,j)
+                  print*, 'ZNT_mosaic', ZNT_mosaic(i, mosaic_i,j), 'Z0_mosaic', Z0_mosaic(i,mosaic_i,j) 
+                  print*, 'FRC_URB2D',FRC_URB2D(I,J)
+                  print*, 'TS_URB',TS_URB2D(I,J),'T1',T1
+                  print*, 'SH_URB2D',SH_URB2D(I,J),'SHEAT',SHEAT
+                  print*, 'LH_URB',LH_URB2D(I,J),'ETA',ETA
+                  print*, 'TS_RUL2D',TS_RUL2D_mosaic(I,mosaic_i,J)
+                  
+            ENDIF
+#endif
+                  
+      !-----------------------------------------------------------------------
+      ! Now let's do the grid-averaging
+      !-----------------------------------------------------------------------
+      
+                  FAREA  = landusef2(i,mosaic_i,j)
+      
+                  TSK_mosaic_avg(i,j) = TSK_mosaic_avg(i,j) + (EMISS_mosaic(i,mosaic_i,j)*TSK_mosaic(i,mosaic_i,j)**4)*FAREA    ! conserve the longwave radiation
+                  
+                  QSFC_mosaic_avg(i,j) = QSFC_mosaic_avg(i,j) + QSFC_mosaic(i,mosaic_i,j)*FAREA
+                  CANWAT_mosaic_avg(i,j) = CANWAT_mosaic_avg(i,j) + CANWAT_mosaic(i,mosaic_i,j)*FAREA
+                  SNOW_mosaic_avg(i,j) = SNOW_mosaic_avg(i,j) + SNOW_mosaic(i,mosaic_i,j)*FAREA
+                  SNOWH_mosaic_avg(i,j) = SNOWH_mosaic_avg(i,j) + SNOWH_mosaic(i,mosaic_i,j)*FAREA
+                  SNOWC_mosaic_avg(i,j) = SNOWC_mosaic_avg(i,j) + SNOWC_mosaic(i,mosaic_i,j)*FAREA
+      
+                   DO NS=1,NSOIL
+      
+                 TSLB_mosaic_avg(i,NS,j)=TSLB_mosaic_avg(i,NS,j) + TSLB_mosaic(i,NS*mosaic_i,j)*FAREA
+                 SMOIS_mosaic_avg(i,NS,j)=SMOIS_mosaic_avg(i,NS,j) + SMOIS_mosaic(i,NS*mosaic_i,j)*FAREA
+                 SH2O_mosaic_avg(i,NS,j)=SH2O_mosaic_avg(i,NS,j) + SH2O_mosaic(i,NS*mosaic_i,j)*FAREA
+      
+                   ENDDO
+      
+                  FAREA_mosaic_avg(i,j)=FAREA_mosaic_avg(i,j)+FAREA
+                  HFX_mosaic_avg(i,j) = HFX_mosaic_avg(i,j) + HFX_mosaic(i,mosaic_i,j)*FAREA
+                  QFX_mosaic_avg(i,j) = QFX_mosaic_avg(i,j) + QFX_mosaic(i,mosaic_i,j)*FAREA
+                  LH_mosaic_avg(i,j) = LH_mosaic_avg(i,j) + LH_mosaic(i,mosaic_i,j)*FAREA
+                  GRDFLX_mosaic_avg(i,j)=GRDFLX_mosaic_avg(i,j)+GRDFLX_mosaic(i,mosaic_i,j)*FAREA
+                  
+                  ALBEDO_mosaic_avg(i,j)=ALBEDO_mosaic_avg(i,j)+ALBEDO_mosaic(i,mosaic_i,j)*FAREA
+                  ALBBCK_mosaic_avg(i,j)=ALBBCK_mosaic_avg(i,j)+ALBBCK_mosaic(i,mosaic_i,j)*FAREA
+                  EMISS_mosaic_avg(i,j)=EMISS_mosaic_avg(i,j)+EMISS_mosaic(i,mosaic_i,j)*FAREA
+                  EMBCK_mosaic_avg(i,j)=EMBCK_mosaic_avg(i,j)+EMBCK_mosaic(i,mosaic_i,j)*FAREA
+                  ZNT_mosaic_avg(i,j)=ZNT_mosaic_avg(i,j)+ALOG(ZNT_mosaic(i,mosaic_i,j))*FAREA
+                  Z0_mosaic_avg(i,j)=Z0_mosaic_avg(i,j)+ALOG(Z0_mosaic(i,mosaic_i,j))*FAREA
+!  print*, '2D Mosaic grid-averaging, FAREA, TSK_mosaic_avg(i,j), TSLB_mosaic_avg(i,1,j), ZNT_mosaic_avg(i,j), EMISS_mosaic_avg(i,j) = ', &
+!          FAREA, TSK_mosaic_avg(i,j), TSLB_mosaic_avg(i,1,j), ZNT_mosaic_avg(i,j), EMISS_mosaic_avg(i,j)
+     
+         ENDDO                     ! ENDDO FOR mosaic_i = 1, mosaic_cat
+      !-----------------------------------------------------------------------
+      ! Now let's send the 3D values to the 2D variables that might be needed in other routines
+      !-----------------------------------------------------------------------
+      
+          IVGTYP(I,J)=IVGTYP_dominant(I,J)                                 ! the dominant vege category 
+          ALBEDO(i,j)=ALBEDO_mosaic_avg(i,j)
+          ALBBCK(i,j)=ALBBCK_mosaic_avg(i,j) 
+          EMISS(i,j)= EMISS_mosaic_avg(i,j) 
+          EMBCK(i,j)= EMBCK_mosaic_avg(i,j)  
+          ZNT(i,j)= EXP(ZNT_mosaic_avg(i,j)/FAREA_mosaic_avg(i,j))
+          Z0(i,j)= EXP(Z0_mosaic_avg(i,j)/FAREA_mosaic_avg(i,j))
+                                                                                       
+          TSK(i,j)=(TSK_mosaic_avg(I,J)/EMISS_mosaic_avg(I,J))**(0.25)                                  ! from 3D to 2D
+          QSFC(i,j)=QSFC_mosaic_avg(I,J)
+          CANWAT(i,j) = CANWAT_mosaic_avg(i,j)
+          SNOW(i,j) = SNOW_mosaic_avg(i,j)
+          SNOWH(i,j) = SNOWH_mosaic_avg(i,j)  
+          SNOWC(i,j) = SNOWC_mosaic_avg(i,j)    
+          
+          HFX(i,j) = HFX_mosaic_avg(i,j) 
+          QFX(i,j) = QFX_mosaic_avg(i,j) 
+          LH(i,j) = LH_mosaic_avg(i,j) 
+          GRDFLX(i,j)=GRDFLX_mosaic_avg(i,j)
+        
+                    DO NS=1,NSOIL
+      
+               TSLB(i,NS,j)=TSLB_mosaic_avg(i,NS,j)
+               SMOIS(i,NS,j)=SMOIS_mosaic_avg(i,NS,j)
+               SH2O(i,NS,j)=SH2O_mosaic_avg(i,NS,j)
+      
+                    ENDDO
+!      print*, '3D Mosaic grid-averaging, FAREA_mosaic_avg(i,j), TSK_avg(i,j), TSLB(i,1,j), ZNT(i,j) = ', FAREA_mosaic_avg(i,j), TSK(i,j), TSLB(i,1,j), ZNT(i,j)
+
+      ELSE    ! This corresponds to IF ((sf_surface_mosaic == 1) .AND. ((XLAND(I,J)-1.5).LT.0.) .AND. (XICE(I,J) < XICE_THRESHOLD) ) THEN
+      
+      ! surface pressure
+              PSFC=P8w3D(i,1,j)
+      ! pressure in middle of lowest layer
+              SFCPRS=(P8W3D(I,KTS+1,j)+P8W3D(i,KTS,j))*0.5
+      ! convert from mixing ratio to specific humidity
+               Q2K=QV3D(i,1,j)/(1.0+QV3D(i,1,j))
+      !
+      !         Q2SAT=QGH(I,j)
+               Q2SAT=QGH(I,J)/(1.0+QGH(I,J))        ! Q2SAT is sp humidity
+      ! add check on myj=.true.
+      !        IF((Q2K.GE.Q2SAT*TRESH).AND.Q2K.LT.QZ0(I,J))THEN
+              IF((myj).AND.(Q2K.GE.Q2SAT*TRESH).AND.Q2K.LT.QZ0(I,J))THEN
+                SATFLG=0.
+                CHKLOWQ(I,J)=0.
+              ELSE
+                SATFLG=1.0
+                CHKLOWQ(I,J)=1.
+              ENDIF
+      
+              SFCTMP=T3D(i,1,j)
+              ZLVL=0.5*DZ8W(i,1,j)
+      
+      !        TH2=SFCTMP+(0.0097545*ZLVL)
+      ! calculate SFCTH2 via Exner function vs lapse-rate (above)
+               APES=(1.E5/PSFC)**CAPA
+               APELM=(1.E5/SFCPRS)**CAPA
+               SFCTH2=SFCTMP*APELM
+               TH2=SFCTH2/APES
+      !
+               EMISSI = EMISS(I,J)
+               LWDN=GLW(I,J)*EMISSI
+      ! SOLDN is total incoming solar
+              SOLDN=SWDOWN(I,J)
+      ! GSW is net downward solar
+      !        SOLNET=GSW(I,J)
+      ! use mid-day albedo to determine net downward solar (no solar zenith angle correction)
+              SOLNET=SOLDN*(1.-ALBEDO(I,J))
+              PRCP=RAINBL(i,j)/DT
+              VEGTYP=IVGTYP(I,J)
+              SOILTYP=ISLTYP(I,J)
+              SHDFAC=VEGFRA(I,J)/100.
+              T1=TSK(I,J)
+              CHK=CHS(I,J)
+              SHMIN=SHDMIN(I,J)/100. !NEW
+              SHMAX=SHDMAX(I,J)/100. !NEW
+      ! convert snow water equivalent from mm to meter
+              SNEQV=SNOW(I,J)*0.001
+      ! snow depth in meters
+              SNOWHK=SNOWH(I,J)
+              SNCOVR=SNOWC(I,J)
+      
+      ! if "SR" present, set frac of frozen precip ("FFROZP") = snow-ratio ("SR", range:0-1)
+      ! SR from e.g. Ferrier microphysics
+      ! otherwise define from 1st atmos level temperature
+             IF(FRPCPN) THEN
+                FFROZP=SR(I,J)
+              ELSE
+                IF (SFCTMP <=  273.15) THEN
+                  FFROZP = 1.0
+      	  ELSE
+      	    FFROZP = 0.0
+      	  ENDIF
+              ENDIF
+      !***
+              IF((XLAND(I,J)-1.5).GE.0.)THEN                                  ! begining of land/sea if block
+      ! Open water points
+                TSK_RURAL(I,J)=TSK(I,J)
+                HFX_RURAL(I,J)=HFX(I,J)
+                QFX_RURAL(I,J)=QFX(I,J)
+                LH_RURAL(I,J)=LH(I,J)
+                EMISS_RURAL(I,J)=EMISS(I,J)
+                GRDFLX_RURAL(I,J)=GRDFLX(I,J)
+              ELSE
+      ! Land or sea-ice case
+      
+                IF (XICE(I,J) >= XICE_THRESHOLD) THEN
+                   ! Sea-ice point
+                   ICE = 1
+                ELSE IF ( VEGTYP == ISICE ) THEN
+                   ! Land-ice point
+                   ICE = -1
+                ELSE
+                   ! Neither sea ice or land ice.
+                   ICE=0
+                ENDIF
+                DQSDT2=Q2SAT*A23M4/(SFCTMP-A4)**2
+      
+                IF(SNOW(I,J).GT.0.0)THEN
+      ! snow on surface (use ice saturation properties)
+                  SFCTSNO=SFCTMP
+                  E2SAT=611.2*EXP(6174.*(1./273.15 - 1./SFCTSNO))
+                  Q2SATI=0.622*E2SAT/(SFCPRS-E2SAT)
+                  Q2SATI=Q2SATI/(1.0+Q2SATI)    ! spec. hum.
+                  IF (T1 .GT. 273.14) THEN
+      ! warm ground temps, weight the saturation between ice and water according to SNOWC
+                    Q2SAT=Q2SAT*(1.-SNOWC(I,J)) + Q2SATI*SNOWC(I,J)
+                    DQSDT2=DQSDT2*(1.-SNOWC(I,J)) + Q2SATI*6174./(SFCTSNO**2)*SNOWC(I,J)
+                  ELSE
+      ! cold ground temps, use ice saturation only
+                    Q2SAT=Q2SATI
+                    DQSDT2=Q2SATI*6174./(SFCTSNO**2)
+                  ENDIF
+      ! for snow cover fraction at 0 C, ground temp will not change, so DQSDT2 effectively zero
+                  IF(T1 .GT. 273. .AND. SNOWC(I,J) .GT. 0.)DQSDT2=DQSDT2*(1.-SNOWC(I,J))
+                ENDIF
+      
+                ! Land-ice or land points use the usual deep-soil temperature.
+                TBOT=TMN(I,J)
+      
+                IF(VEGTYP.EQ.25) SHDFAC=0.0000
+                IF(VEGTYP.EQ.26) SHDFAC=0.0000
+                IF(VEGTYP.EQ.27) SHDFAC=0.0000
+                IF(SOILTYP.EQ.14.AND.XICE(I,J).EQ.0.)THEN
+#if 0
+               IF(IPRINT)PRINT*,' SOIL TYPE FOUND TO BE WATER AT A LAND-POINT'
+               IF(IPRINT)PRINT*,i,j,'RESET SOIL in surfce.F'
+#endif
+                  SOILTYP=7
+                ENDIF
+                SNOALB1 = SNOALB(I,J)
+                CMC=CANWAT(I,J)
+      
+      !-------------------------------------------
+      !*** convert snow depth from mm to meter
+      !
+      !          IF(RDMAXALB) THEN
+      !           SNOALB=ALBMAX(I,J)*0.01
+      !         ELSE
+      !           SNOALB=MAXALB(IVGTPK)*0.01
+      !         ENDIF
+      
+      !        SNOALB1=0.80
+      !        SHMIN=0.00
+              ALBBRD=ALBBCK(I,J)
+              Z0BRD=Z0(I,J)
+              EMBRD=EMBCK(I,J)
+              SNOTIME1 = SNOTIME(I,J)
+              RIBB=RIB(I,J)
+      !FEI: temporaray arrays above need to be changed later by using SI
+      
+                DO NS=1,NSOIL
+                  SMC(NS)=SMOIS(I,NS,J)
+                  STC(NS)=TSLB(I,NS,J)                                          !STEMP
+                  SWC(NS)=SH2O(I,NS,J)
+                ENDDO
+      !
+                if ( (SNEQV.ne.0..AND.SNOWHK.eq.0.).or.(SNOWHK.le.SNEQV) )THEN
+                  SNOWHK= 5.*SNEQV
+                endif
+      !
+      
+      !Fei: urban. for urban surface, if calling UCM, redefine the natural surface in cities as
+      ! the "NATURAL" category in the VEGPARM.TBL
+      	
+      	   IF(SF_URBAN_PHYSICS == 1.OR. SF_URBAN_PHYSICS==2.OR.SF_URBAN_PHYSICS==3 ) THEN
+                      IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                        IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+      		 VEGTYP = NATURAL
+                       SHDFAC = SHDTBL(NATURAL)
+                       ALBEDOK =0.2         !  0.2
+                       ALBBRD  =0.2         !0.2
+                       EMISSI = 0.98                                 !for VEGTYP=5
+      		 IF ( FRC_URB2D(I,J) < 0.99 ) THEN
+                         if(sf_urban_physics.eq.1)then
+                 T1= ( TSK(I,J) -FRC_URB2D(I,J) * TS_URB2D (I,J) )/ (1-FRC_URB2D(I,J))
+                         elseif((sf_urban_physics.eq.2).OR.(sf_urban_physics.eq.3))then
+                      r1= (tsk(i,j)**4.)
+                      r2= frc_urb2d(i,j)*(ts_urb2d(i,j)**4.)
+                      r3= (1.-frc_urb2d(i,j))
+                      t1= ((r1-r2)/r3)**.25
+                         endif
+      	         ELSE
+      		 T1 = TSK(I,J)
+                       ENDIF
+                      ENDIF
+                 ELSE
+                       IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                        IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+                        VEGTYP = ISURBAN
+                 	 ENDIF
+                 ENDIF
+
+
+!===Yang, 2014/10/08, hydrological processes for urban vegetation in single layer UCM===
+!           AOASIS = 1.0
+!           USOIL = 1
+!           DSOIL = 2
+!           IRIOPTION=IRI_SCHEME
+!           OMG= OMG_URB2D(I,J)   
+!           tloc=mod(int(OMG/3.14159*180./15.+12.+0.5 ),24)
+!           if (tloc.lt.0) tloc=tloc+24
+!           if (tloc==0) tloc=24
+!           CALL cal_mon_day(julian,julyr,jmonth,jday) 
+!	  IF(SF_URBAN_PHYSICS == 1) THEN
+!           IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+!                IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+!            AOASIS = oasis  ! urban oasis effect
+!                   IF (IRIOPTION ==1) THEN
+!                   IF (tloc==21 .or. tloc==22) THEN  !irrigation on vegetaion in urban area, MAY-SEP, 9-10pm
+!                   IF (jmonth==5 .or. jmonth==6 .or. jmonth==7 .or. jmonth==8 .or. jmonth==9) THEN
+!                      IF (SMC(USOIL) .LT. SMCREF) SMC(USOIL)= REFSMC(ISLTYP(I,J))
+!                      IF (SMC(DSOIL) .LT. SMCREF) SMC(DSOIL)= REFSMC(ISLTYP(I,J))
+!                   ENDIF
+!                   ENDIF
+!                   ENDIF
+!                ENDIF
+!           ENDIF
+
+!	  IF(SF_URBAN_PHYSICS == 2 .or. SF_URBAN_PHYSICS == 3) THEN
+!          IF(AOASIS > 1.0) THEN
+!          CALL wrf_error_fatal('Urban oasis option is for SF_URBAN_PHYSICS == 1 only')
+!          ENDIF
+!          IF(IRIOPTION == 1) THEN
+!          CALL wrf_error_fatal('Urban irrigation option is for SF_URBAN_PHYSICS == 1 only')
+!          ENDIF
+!          ENDIF
+
+            IF( SF_URBAN_PHYSICS==2.OR.SF_URBAN_PHYSICS==3 ) THEN
+!             print*, 'MOSAIC is not designed to work with SF_URBAN_PHYSICS=2 or SF_URBAN_PHYSICS=3'
+            ENDIF
+
+#if 0
+                IF(IPRINT) THEN
+      !
+             print*, 'BEFORE SFLX, in Mosaic Noahlsm_driver'
+             print*, 'ICE', ICE, 'DT',DT, 'ZLVL',ZLVL, 'NSOIL', NSOIL,   &
+             'SLDPTH', SLDPTH, 'LOCAL',LOCAL, 'LUTYPE',&
+              LUTYPE, 'SLTYPE',SLTYPE, 'LWDN',LWDN, 'SOLDN',SOLDN,      &
+              'SFCPRS',SFCPRS, 'PRCP',PRCP,'SFCTMP',SFCTMP,'Q2K',Q2K,   &
+               'TH2',TH2,'Q2SAT',Q2SAT,'DQSDT2',DQSDT2,'VEGTYP', VEGTYP,&
+               'SOILTYP',SOILTYP, 'SLOPETYP',SLOPETYP, 'SHDFAC',SHDFAC,&
+               'SHMIN',SHMIN, 'ALBBRD',ALBBRD,'SNOALB1',SNOALB1,'TBOT',&
+                TBOT, 'Z0BRD',Z0BRD, 'Z0K',Z0K, 'CMC',CMC, 'T1',T1,'STC',&
+                STC, 'SMC',SMC, 'SWC',SWC,'SNOWHK',SNOWHK,'SNEQV',SNEQV,&
+                'ALBEDOK',ALBEDOK,'CHK',CHK,'ETA',ETA,'SHEAT',SHEAT,      &
+                'ETA_KINEMATIC',ETA_KINEMATIC, 'FDOWN',FDOWN,'EC',EC,   &
+                'EDIR',EDIR,'ET',ET,'ETT',ETT,'ESNOW',ESNOW,'DRIP',DRIP,&
+                'DEW',DEW,'BETA',BETA,'ETP',ETP,'SSOIL',SSOIL,'FLX1',FLX1,&
+                'FLX2',FLX2,'FLX3',FLX3,'SNOMLT',SNOMLT,'SNCOVR',SNCOVR,&
+                'RUNOFF1',RUNOFF1,'RUNOFF2',RUNOFF2,'RUNOFF3',RUNOFF3, &
+                'RC',RC, 'PC',PC,'RSMIN',RSMIN,'XLAI',XLAI,'RCS',RCS,  &
+                'RCT',RCT,'RCQ',RCQ,'RCSOIL',RCSOIL,'SOILW',SOILW,     &
+                'SOILM',SOILM,'Q1',Q1,'SMCWLT',SMCWLT,'SMCDRY',SMCDRY,&
+                'SMCREF',SMCREF,'SMCMAX',SMCMAX,'NROOT',NROOT
+                 endif
+#endif
+      
+                IF (rdlai2d) THEN
+                   xlai = lai(i,j)
+                endif
+      
+      
+             CALL SFLX (FFROZP, ICE, ISURBAN, DT,ZLVL,NSOIL,SLDPTH,       &    !C
+                       LOCAL,                                            &    !L
+                       LUTYPE, SLTYPE,                                   &    !CL
+                       LWDN,SOLDN,SOLNET,SFCPRS,PRCP,SFCTMP,Q2K,DUMMY,   &    !F
+                       DUMMY,DUMMY, DUMMY,                               &    !F PRCPRAIN not used
+                       TH2,Q2SAT,DQSDT2,                                 &    !I
+                       VEGTYP,SOILTYP,SLOPETYP,SHDFAC,SHMIN,SHMAX,       &    !I
+                       ALBBRD, SNOALB1,TBOT, Z0BRD, Z0K, EMISSI, EMBRD,  &    !S
+                       CMC,T1,STC,SMC,SWC,SNOWHK,SNEQV,ALBEDOK,CHK,dummy,&    !H
+                       ETA,SHEAT, ETA_KINEMATIC,FDOWN,                   &    !O
+                       EC,EDIR,ET,ETT,ESNOW,DRIP,DEW,                    &    !O
+                       BETA,ETP,SSOIL,                                   &    !O
+                       FLX1,FLX2,FLX3,                                   &    !O
+      		       SNOMLT,SNCOVR,                                    &    !O
+                       RUNOFF1,RUNOFF2,RUNOFF3,                          &    !O
+                       RC,PC,RSMIN,XLAI,RCS,RCT,RCQ,RCSOIL,              &    !O
+                       SOILW,SOILM,Q1,SMAV,                              &    !D
+                       RDLAI2D,USEMONALB,                                &
+                       SNOTIME1,                                         &
+                       RIBB,                                             &
+                       SMCWLT,SMCDRY,SMCREF,SMCMAX,NROOT)
+       
+            lai(i,j) = xlai
+      
+#if 0
+                IF(IPRINT) THEN
+      
+             print*, 'AFTER SFLX, in Mosaic Noahlsm_driver'
+             print*, 'ICE', ICE, 'DT',DT, 'ZLVL',ZLVL, 'NSOIL', NSOIL,   &
+             'SLDPTH', SLDPTH, 'LOCAL',LOCAL, 'LUTYPE',&
+              LUTYPE, 'SLTYPE',SLTYPE, 'LWDN',LWDN, 'SOLDN',SOLDN,      &
+              'SFCPRS',SFCPRS, 'PRCP',PRCP,'SFCTMP',SFCTMP,'Q2K',Q2K,   &
+               'TH2',TH2,'Q2SAT',Q2SAT,'DQSDT2',DQSDT2,'VEGTYP', VEGTYP,&
+                'SOILTYP',SOILTYP, 'SLOPETYP',SLOPETYP, 'SHDFAC',SHDFAC,&
+               'SHDMIN',SHMIN, 'ALBBRD',ALBBRD,'SNOALB',SNOALB1,'TBOT',&
+                TBOT, 'Z0BRD',Z0BRD, 'Z0K',Z0K, 'CMC',CMC, 'T1',T1,'STC',&
+                STC, 'SMC',SMC, 'SWc',SWC,'SNOWHK',SNOWHK,'SNEQV',SNEQV,&
+                'ALBEDOK',ALBEDOK,'CHK',CHK,'ETA',ETA,'SHEAT',SHEAT,      &
+                'ETA_KINEMATIC',ETA_KINEMATIC, 'FDOWN',FDOWN,'EC',EC,   &
+                'EDIR',EDIR,'ET',ET,'ETT',ETT,'ESNOW',ESNOW,'DRIP',DRIP,&
+                'DEW',DEW,'BETA',BETA,'ETP',ETP,'SSOIL',SSOIL,'FLX1',FLX1,&
+                'FLX2',FLX2,'FLX3',FLX3,'SNOMLT',SNOMLT,'SNCOVR',SNCOVR,&
+                'RUNOFF1',RUNOFF1,'RUNOFF2',RUNOFF2,'RUNOFF3',RUNOFF3, &
+                'RC',RC, 'PC',PC,'RSMIN',RSMIN,'XLAI',XLAI,'RCS',RCS,  &
+                'RCT',RCT,'RCQ',RCQ,'RCSOIL',RCSOIL,'SOILW',SOILW,     &
+                'SOILM',SOILM,'Q1',Q1,'SMCWLT',SMCWLT,'SMCDRY',SMCDRY,&
+                'SMCREF',SMCREF,'SMCMAX',SMCMAX,'NROOT',NROOT
+                 endif
+#endif
+      
+      !***  UPDATE STATE VARIABLES
+                CANWAT(I,J)=CMC
+                SNOW(I,J)=SNEQV*1000.
+      !          SNOWH(I,J)=SNOWHK*1000.
+                SNOWH(I,J)=SNOWHK                   ! SNOWHK in meters
+                ALBEDO(I,J)=ALBEDOK
+                ALB_RURAL(I,J)=ALBEDOK
+                ALBBCK(I,J)=ALBBRD
+                Z0(I,J)=Z0BRD
+                EMISS(I,J) = EMISSI
+                EMISS_RURAL(I,J) = EMISSI
+      ! Noah: activate time-varying roughness length (V3.3 Feb 2011)
+                ZNT(I,J)=Z0K
+                TSK(I,J)=T1
+                TSK_RURAL(I,J)=T1
+                HFX(I,J)=SHEAT
+                HFX_RURAL(I,J)=SHEAT
+      ! MEk Jul07 add potential evap accum
+              POTEVP(I,J)=POTEVP(I,J)+ETP*FDTW
+                QFX(I,J)=ETA_KINEMATIC
+                QFX_RURAL(I,J)=ETA_KINEMATIC
+      
+
+                LH(I,J)=ETA
+                LH_RURAL(I,J)=ETA
+                GRDFLX(I,J)=SSOIL
+                GRDFLX_RURAL(I,J)=SSOIL
+                SNOWC(I,J)=SNCOVR
+                CHS2(I,J)=CQS2(I,J)
+                SNOTIME(I,J) = SNOTIME1
+      !      prevent diagnostic ground q (q1) from being greater than qsat(tsk)
+      !      as happens over snow cover where the cqs2 value also becomes irrelevant
+      !      by setting cqs2=chs in this situation the 2m q should become just qv(k=1)
+                IF (Q1 .GT. QSFC(I,J)) THEN
+                  CQS2(I,J) = CHS(I,J)
+                ENDIF
+      !          QSFC(I,J)=Q1
+      ! Convert QSFC back to mixing ratio
+                 QSFC(I,J)= Q1/(1.0-Q1)
+      !
+                 QSFC_RURAL(I,J)= Q1/(1.0-Q1)
+      ! Calculate momentum flux from rural surface for use with multi-layer UCM (Martilli et al. 2002)
+      
+                DO 80 NS=1,NSOIL
+                 SMOIS(I,NS,J)=SMC(NS)
+                 TSLB(I,NS,J)=STC(NS)                                        !  STEMP
+                 SH2O(I,NS,J)=SWC(NS)
+         80     CONTINUE
+      !       ENDIF
+      
+             
+           !
+           ! Residual of surface energy balance equation terms
+           !
+              noahres(i,j) =     ( solnet + lwdn ) - sheat + ssoil - eta - ( emissi * STBOLT * (t1**4) ) - flx1 - flx2 - flx3
+       
+              IF (SF_URBAN_PHYSICS == 1 ) THEN                                              ! Beginning of UCM CALL if block
+      !--------------------------------------
+      ! URBAN CANOPY MODEL START - urban
+      !--------------------------------------
+      ! Input variables lsm --> urban
+      
+                IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                    IVGTYP(I,J) == 32 .or. IVGTYP(I,J) ==  33) THEN
+      
+      ! Call urban
+      !
+                  UTYPE_URB = UTYPE_URB2D(I,J) !urban type (low, high or industrial)
+      
+                  TA_URB    = SFCTMP           ! [K]
+                  QA_URB    = Q2K              ! [kg/kg]
+                  UA_URB    = SQRT(U_PHY(I,1,J)**2.+V_PHY(I,1,J)**2.)
+                  U1_URB    = U_PHY(I,1,J)
+                  V1_URB    = V_PHY(I,1,J)
+                  IF(UA_URB < 1.) UA_URB=1.    ! [m/s]
+                  SSG_URB   = SOLDN            ! [W/m/m]
+                  SSGD_URB  = 0.8*SOLDN        ! [W/m/m]
+                  SSGQ_URB  = SSG_URB-SSGD_URB ! [W/m/m]
+                  LLG_URB   = GLW(I,J)         ! [W/m/m]
+                  RAIN_URB  = RAINBL(I,J)      ! [mm]
+                  RHOO_URB  = SFCPRS / (287.04 * SFCTMP * (1.0+ 0.61 * Q2K)) ![kg/m/m/m]
+                  ZA_URB    = ZLVL             ! [m]
+                  DELT_URB  = DT               ! [sec]
+                  XLAT_URB  = XLAT_URB2D(I,J)  ! [deg]
+                  COSZ_URB  = COSZ_URB2D(I,J)  !
+                  OMG_URB   = OMG_URB2D(I,J)   !
+                  ZNT_URB   = ZNT(I,J)
+      
+                  LSOLAR_URB = .FALSE.
+      
+                  TR_URB = TR_URB2D(I,J)
+                  TB_URB = TB_URB2D(I,J)
+                  TG_URB = TG_URB2D(I,J)
+                  TC_URB = TC_URB2D(I,J)
+                  QC_URB = QC_URB2D(I,J)
+                  UC_URB = UC_URB2D(I,J)
+      
+                  DO K = 1,num_roof_layers
+                    TRL_URB(K) = TRL_URB3D(I,K,J)
+                    
+                  END DO
+                  DO K = 1,num_wall_layers
+                    TBL_URB(K) = TBL_URB3D(I,K,J)
+                  END DO
+                  DO K = 1,num_road_layers
+                    TGL_URB(K) = TGL_URB3D(I,K,J)
+                  END DO
+
+                       
+                  XXXR_URB = XXXR_URB2D(I,J)
+                  XXXB_URB = XXXB_URB2D(I,J)
+                  XXXG_URB = XXXG_URB2D(I,J)
+                  XXXC_URB = XXXC_URB2D(I,J)
+      !
+      !      Limits to avoid dividing by small number
+                  if (CHS(I,J) < 1.0E-02) then
+                     CHS(I,J)  = 1.0E-02
+                  endif
+                  if (CHS2(I,J) < 1.0E-02) then
+                     CHS2(I,J)  = 1.0E-02
+                  endif
+                  if (CQS2(I,J) < 1.0E-02) then
+                     CQS2(I,J)  = 1.0E-02
+                  endif
+      !
+                  CHS_URB  = CHS(I,J)
+                  CHS2_URB = CHS2(I,J)
+                  IF (PRESENT(CMR_SFCDIF)) THEN
+                     CMR_URB = CMR_SFCDIF(I,J)
+                     CHR_URB = CHR_SFCDIF(I,J)
+                     CMC_URB = CMC_SFCDIF(I,J)
+                     CHC_URB = CHC_SFCDIF(I,J)
+                  ENDIF
+      
+      
+      !
+      ! Call urban
+                    
+                  CALL urban(LSOLAR_URB,                                      & ! I
+                             num_roof_layers,num_wall_layers,num_road_layers, & ! C
+                             DZR,DZB,DZG,                                     & ! C
+                             UTYPE_URB,TA_URB,QA_URB,UA_URB,U1_URB,V1_URB,SSG_URB, & ! I
+                             SSGD_URB,SSGQ_URB,LLG_URB,RAIN_URB,RHOO_URB,     & ! I
+                             ZA_URB,DECLIN_URB,COSZ_URB,OMG_URB,              & ! I
+                             XLAT_URB,DELT_URB,ZNT_URB,                       & ! I
+                             CHS_URB, CHS2_URB,                               & ! I
+                             TR_URB, TB_URB, TG_URB, TC_URB, QC_URB,UC_URB,   & ! H
+                             TRL_URB,TBL_URB,TGL_URB,                         & ! H
+                             XXXR_URB, XXXB_URB, XXXG_URB, XXXC_URB,          & ! H
+                             TS_URB,QS_URB,SH_URB,LH_URB,LH_KINEMATIC_URB,    & ! O
+                             SW_URB,ALB_URB,LW_URB,G_URB,RN_URB,PSIM_URB,PSIH_URB, & ! O
+                             GZ1OZ0_URB,                                      & !O
+                             CMR_URB, CHR_URB, CMC_URB, CHC_URB,              &
+                             U10_URB, V10_URB, TH2_URB, Q2_URB,               & ! O
+                             UST_URB)  
+      
+#if 0
+                IF(IPRINT) THEN
+      
+             print*, 'AFTER CALL URBAN Noah Mosaic'
+             print*,'num_roof_layers',num_roof_layers, 'num_wall_layers',  &
+              num_wall_layers,                                             &
+             'DZR',DZR,'DZB',DZB,'DZG',DZG,'UTYPE_URB',UTYPE_URB,'TA_URB', &
+              TA_URB,                                                      &
+              'QA_URB',QA_URB,'UA_URB',UA_URB,'U1_URB',U1_URB,'V1_URB',    &
+               V1_URB,                                                     &
+               'SSG_URB',SSG_URB,'SSGD_URB',SSGD_URB,'SSGQ_URB',SSGQ_URB,  &
+              'LLG_URB',LLG_URB,'RAIN_URB',RAIN_URB,'RHOO_URB',RHOO_URB,   &
+              'ZA_URB',ZA_URB, 'DECLIN_URB',DECLIN_URB,'COSZ_URB',COSZ_URB,&
+              'OMG_URB',OMG_URB,'XLAT_URB',XLAT_URB,'DELT_URB',DELT_URB,   &
+               'ZNT_URB',ZNT_URB,'TR_URB',TR_URB, 'TB_URB',TB_URB,'TG_URB',&
+               TG_URB,'TC_URB',TC_URB,'QC_URB',QC_URB,'TRL_URB',TRL_URB,   &
+                'TBL_URB',TBL_URB,'TGL_URB',TGL_URB,'XXXR_URB',XXXR_URB,   &
+               'XXXB_URB',XXXB_URB,'XXXG_URB',XXXG_URB,'XXXC_URB',XXXC_URB,&
+               'TS_URB',TS_URB,'QS_URB',QS_URB,'SH_URB',SH_URB,'LH_URB',   &
+               LH_URB, 'LH_KINEMATIC_URB',LH_KINEMATIC_URB,'SW_URB',SW_URB,&
+               'ALB_URB',ALB_URB,'LW_URB',LW_URB,'G_URB',G_URB,'RN_URB',   &
+                RN_URB, 'PSIM_URB',PSIM_URB,'PSIH_URB',PSIH_URB,          &
+               'U10_URB',U10_URB,'V10_URB',V10_URB,'TH2_URB',TH2_URB,      &
+                'Q2_URB',Q2_URB,'CHS_URB',CHS_URB,'CHS2_URB',CHS2_URB
+                 endif
+#endif
+      
+                  TS_URB2D(I,J) = TS_URB
+      
+                  ALBEDO(I,J) = FRC_URB2D(I,J)*ALB_URB+(1-FRC_URB2D(I,J))*ALBEDOK   ![-]
+                  HFX(I,J) = FRC_URB2D(I,J)*SH_URB+(1-FRC_URB2D(I,J))*SHEAT         ![W/m/m]
+                  QFX(I,J) = FRC_URB2D(I,J)*LH_KINEMATIC_URB &
+                           + (1-FRC_URB2D(I,J))*ETA_KINEMATIC                ![kg/m/m/s]
+                  LH(I,J) = FRC_URB2D(I,J)*LH_URB+(1-FRC_URB2D(I,J))*ETA            ![W/m/m]
+                  GRDFLX(I,J) = FRC_URB2D(I,J)*G_URB+(1-FRC_URB2D(I,J))*SSOIL       ![W/m/m]
+                  TSK(I,J) = FRC_URB2D(I,J)*TS_URB+(1-FRC_URB2D(I,J))*T1            ![K]
+                  Q1 = FRC_URB2D(I,J)*QS_URB+(1-FRC_URB2D(I,J))*Q1            ![-]
+      ! Convert QSFC back to mixing ratio
+                  QSFC(I,J)= Q1/(1.0-Q1)
+                  UST(I,J)= FRC_URB2D(I,J)*UST_URB+(1-FRC_URB2D(I,J))*UST(I,J)      ![m/s]
+      
+#if 0
+          IF(IPRINT)THEN
+      
+          print*, ' FRC_URB2D', FRC_URB2D,                        &
+          'ALB_URB',ALB_URB, 'ALBEDOK',ALBEDOK, &
+          'ALBEDO(I,J)',  ALBEDO(I,J),                  &
+          'SH_URB',SH_URB,'SHEAT',SHEAT, 'HFX(I,J)',HFX(I,J),  &
+          'LH_KINEMATIC_URB',LH_KINEMATIC_URB,'ETA_KINEMATIC',  &
+           ETA_KINEMATIC, 'QFX(I,J)',QFX(I,J),                  &
+          'LH_URB',LH_URB, 'ETA',ETA, 'LH(I,J)',LH(I,J),        &
+          'G_URB',G_URB,'SSOIL',SSOIL,'GRDFLX(I,J)', GRDFLX(I,J),&
+          'TS_URB',TS_URB,'T1',T1,'TSK(I,J)',TSK(I,J),          &
+          'QS_URB',QS_URB,'Q1',Q1,'QSFC(I,J)',QSFC(I,J)
+           endif
+#endif
+      
+      ! Renew Urban State Varialbes
+      
+                  TR_URB2D(I,J) = TR_URB
+                  TB_URB2D(I,J) = TB_URB
+                  TG_URB2D(I,J) = TG_URB
+                  TC_URB2D(I,J) = TC_URB
+                  QC_URB2D(I,J) = QC_URB
+                  UC_URB2D(I,J) = UC_URB
+      
+                  DO K = 1,num_roof_layers
+                    TRL_URB3D(I,K,J) = TRL_URB(K)
+                    
+                  END DO
+                  DO K = 1,num_wall_layers
+                    TBL_URB3D(I,K,J) = TBL_URB(K)
+                  END DO
+                  DO K = 1,num_road_layers
+                    TGL_URB3D(I,K,J) = TGL_URB(K)
+                  END DO
+                 
+                  
+
+                  XXXR_URB2D(I,J) = XXXR_URB
+                  XXXB_URB2D(I,J) = XXXB_URB
+                  XXXG_URB2D(I,J) = XXXG_URB
+                  XXXC_URB2D(I,J) = XXXC_URB
+      
+                  SH_URB2D(I,J)    = SH_URB
+                  LH_URB2D(I,J)    = LH_URB
+                  G_URB2D(I,J)     = G_URB
+                  RN_URB2D(I,J)    = RN_URB
+                  PSIM_URB2D(I,J)  = PSIM_URB
+                  PSIH_URB2D(I,J)  = PSIH_URB
+                  GZ1OZ0_URB2D(I,J)= GZ1OZ0_URB
+                  U10_URB2D(I,J)   = U10_URB
+                  V10_URB2D(I,J)   = V10_URB
+                  TH2_URB2D(I,J)   = TH2_URB
+                  Q2_URB2D(I,J)    = Q2_URB
+                  UST_URB2D(I,J)   = UST_URB
+                  AKMS_URB2D(I,J)  = KARMAN * UST_URB2D(I,J)/(GZ1OZ0_URB2D(I,J)-PSIM_URB2D(I,J))
+                  IF (PRESENT(CMR_SFCDIF)) THEN
+                     CMR_SFCDIF(I,J) = CMR_URB
+                     CHR_SFCDIF(I,J) = CHR_URB
+                     
+                     CMC_SFCDIF(I,J) = CMC_URB
+                     CHC_SFCDIF(I,J) = CHC_URB
+                  ENDIF
+                END IF
+      
+               ENDIF                                   ! end of UCM CALL if block
+      !--------------------------------------
+      ! Urban Part End - urban
+      !--------------------------------------
+      
+      !***  DIAGNOSTICS
+                SMSTAV(I,J)=SOILW
+                SMSTOT(I,J)=SOILM*1000.
+                DO NS=1,NSOIL
+                SMCREL(I,NS,J)=SMAV(NS)
+                ENDDO
+      
+      !         Convert the water unit into mm
+                SFCRUNOFF(I,J)=SFCRUNOFF(I,J)+RUNOFF1*DT*1000.0
+                UDRUNOFF(I,J)=UDRUNOFF(I,J)+(RUNOFF2+RUNOFF3)*DT*1000.0
+      ! snow defined when fraction of frozen precip (FFROZP) > 0.5,
+                IF(FFROZP.GT.0.5)THEN
+                  ACSNOW(I,J)=ACSNOW(I,J)+PRCP*DT
+                ENDIF
+                IF(SNOW(I,J).GT.0.)THEN
+                  ACSNOM(I,J)=ACSNOM(I,J)+SNOMLT*1000.
+      ! accumulated snow-melt energy
+                  SNOPCX(I,J)=SNOPCX(I,J)-SNOMLT/FDTLIW
+                ENDIF
+      
+              ENDIF                                                           ! endif of land-sea test
+
+      ENDIF                                           ! ENDIF FOR MOSAIC DANLI  ! This corresponds to IF ((sf_surface_mosaic == 1) .AND. ((XLAND(I,J)-1.5).LT.0.) .AND. (XICE(I,J) < XICE_THRESHOLD) ) THEN
+
+    100 CONTINUE                                                          ! of I loop
+
+   ENDDO                                                                ! of J loop   
+       
+!------------------------------------------------------
+   END SUBROUTINE lsm_mosaic
+!------------------------------------------------------
+!following logic of ldf ---pcc (05-18-2017): This section of the Mosaic module is moved to module_physics_lsm_noahinit.F in
+!./../core_physics to accomodate differences in the mpi calls between WRF and MPAS.I thought
+!that it would be cleaner to do this instead of adding a lot of #ifdef statements throughout
+!the initialization subroutine.
+
+#if !defined(mpas)
+!===========================================================================
+!
+! subroutine lsm_mosaic_init: initialization of mosaic state variables
+!
+!===========================================================================   
+  
+   SUBROUTINE lsm_mosaic_init(IVGTYP,ISWATER,ISURBAN,ISICE, XLAND, XICE,fractional_seaice, &
+                  TSK,TSLB,SMOIS,SH2O,SNOW,SNOWC,SNOWH,CANWAT,    &
+                  ids,ide, jds,jde, kds,kde,                      &
+                  ims,ime, jms,jme, kms,kme,                      &
+                  its,ite, jts,jte, kts,kte, restart,             &
+                  landusef,landusef2,NLCAT,num_soil_layers        & 
+                  ,sf_surface_mosaic, mosaic_cat                  & 
+                  ,mosaic_cat_index                               &   
+                  ,TSK_mosaic,TSLB_mosaic                         &
+                  ,SMOIS_mosaic,SH2O_mosaic                       & 
+                  ,CANWAT_mosaic,SNOW_mosaic                      &
+                  ,SNOWH_mosaic,SNOWC_mosaic                      &
+                  ,ALBEDO,ALBBCK, EMISS, EMBCK,Z0                 &  !danli  
+                  ,ALBEDO_mosaic,ALBBCK_mosaic, EMISS_mosaic      &  !danli
+                  ,EMBCK_mosaic, ZNT_mosaic, Z0_mosaic            &  !danli
+                  ,TR_URB2D_mosaic,TB_URB2D_mosaic                &  !danli mosaic 
+                  ,TG_URB2D_mosaic,TC_URB2D_mosaic                &  !danli mosaic 
+                  ,QC_URB2D_mosaic                                &  !danli mosaic                  
+                  ,TRL_URB3D_mosaic,TBL_URB3D_mosaic              &  !danli mosaic 
+                  ,TGL_URB3D_mosaic                               &  !danli mosaic 
+                  ,SH_URB2D_mosaic,LH_URB2D_mosaic                &  !danli mosaic 
+                  ,G_URB2D_mosaic,RN_URB2D_mosaic                 &  !danli mosaic 
+                  ,TS_URB2D_mosaic                                &  !danli mosaic 
+                  ,TS_RUL2D_mosaic                                &  !danli mosaic                    
+                   ) 
+  
+    INTEGER,  INTENT(IN)   ::       ids,ide, jds,jde, kds,kde,  &
+                                    ims,ime, jms,jme, kms,kme,  &
+                                    its,ite, jts,jte, kts,kte 
+
+   INTEGER, INTENT(IN)       ::     NLCAT, num_soil_layers, ISWATER,ISURBAN, ISICE, fractional_seaice
+
+   LOGICAL , INTENT(IN) :: restart 
+
+!   REAL,    DIMENSION( num_soil_layers), INTENT(INOUT) :: ZS, DZS
+
+   REAL,    DIMENSION( ims:ime, num_soil_layers, jms:jme )    , &
+            INTENT(IN)    ::                             SMOIS, &  !Total soil moisture
+                                                         SH2O,  &  !liquid soil moisture       
+                                                         TSLB      !STEMP
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(IN)    ::                           SNOW, &
+                                                         SNOWH, &
+                                                         SNOWC, &
+                                                        CANWAT, &
+                                                        TSK, XICE, XLAND         
+  
+  INTEGER, INTENT(IN) :: sf_surface_mosaic  
+  INTEGER, INTENT(IN) :: mosaic_cat
+  INTEGER, DIMENSION( ims:ime, jms:jme ),INTENT(IN) :: IVGTYP
+  REAL, DIMENSION( ims:ime, NLCAT, jms:jme ) , INTENT(IN)::   LANDUSEF
+  REAL, DIMENSION( ims:ime, NLCAT, jms:jme ) , INTENT(INOUT)::   LANDUSEF2
+  
+  INTEGER, DIMENSION( ims:ime, NLCAT, jms:jme ), INTENT(INOUT) :: mosaic_cat_index 
+
+  REAL, DIMENSION( ims:ime, 1:mosaic_cat, jms:jme ) , OPTIONAL, INTENT(INOUT)::   &
+        TSK_mosaic, CANWAT_mosaic, SNOW_mosaic,SNOWH_mosaic, SNOWC_mosaic 
+  REAL, DIMENSION( ims:ime, 1:num_soil_layers*mosaic_cat, jms:jme ), OPTIONAL, INTENT(INOUT)::   &
+        TSLB_mosaic,SMOIS_mosaic,SH2O_mosaic
+  
+  REAL, DIMENSION( ims:ime, jms:jme ) , INTENT(IN)::   ALBEDO, ALBBCK, EMISS, EMBCK, Z0 
+  REAL, DIMENSION( ims:ime, 1:mosaic_cat, jms:jme ) , OPTIONAL, INTENT(INOUT)::   &
+        ALBEDO_mosaic,ALBBCK_mosaic, EMISS_mosaic, EMBCK_mosaic, ZNT_mosaic, Z0_mosaic
+
+  REAL, DIMENSION( ims:ime, 1:mosaic_cat, jms:jme ) , OPTIONAL, INTENT(INOUT)::   &
+        TR_URB2D_mosaic, TB_URB2D_mosaic, TG_URB2D_mosaic, TC_URB2D_mosaic,QC_URB2D_mosaic,  &
+        SH_URB2D_mosaic,LH_URB2D_mosaic,G_URB2D_mosaic,RN_URB2D_mosaic,TS_URB2D_mosaic, TS_RUL2D_mosaic  
+                    
+  REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_soil_layers*mosaic_cat, jms:jme ), INTENT(INOUT) :: TRL_URB3D_mosaic
+  REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_soil_layers*mosaic_cat, jms:jme ), INTENT(INOUT) :: TBL_URB3D_mosaic
+  REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_soil_layers*mosaic_cat, jms:jme ), INTENT(INOUT) :: TGL_URB3D_mosaic    
+
+  INTEGER :: ij,i,j,mosaic_i,LastSwap,NumPairs,soil_k, Temp2,Temp5,Temp7, ICE,temp_index
+  REAL :: Temp, Temp3,Temp4,Temp6,xice_threshold
+  LOGICAL :: IPRINT
+  CHARACTER(len=256) :: message_text
+
+  IPRINT=.false.
+
+  if ( fractional_seaice == 0 ) then
+     xice_threshold = 0.5
+  else if ( fractional_seaice == 1 ) then
+     xice_threshold = 0.02
+  endif
+
+    IF(.not.restart)THEN
+  !===========================================================================   
+  ! CHOOSE THE TILES
+  !===========================================================================  
+  
+  itf=min0(ite,ide-1)
+  jtf=min0(jte,jde-1)
+
+  ! simple test
+   
+  DO i = its,itf
+     DO j = jts,jtf 
+        IF ((xland(i,j).LT. 1.5 ) .AND. (IVGTYP(i,j) .EQ. ISWATER)) THEN
+           PRINT*, 'BEFORE MOSAIC_INIT'
+           CALL wrf_message("BEFORE MOSAIC_INIT")
+           WRITE(message_text,fmt='(a,2I6,2F8.2,2I6)') 'I,J,xland,xice,mosaic_cat_index,ivgtyp = ', &
+                 I,J,xland(i,j),xice(i,j),mosaic_cat_index(I,1,J),IVGTYP(i,j)
+           CALL wrf_message(message_text)
+        ENDIF
+     ENDDO
+  ENDDO
+
+     DO i = its,itf
+        DO j = jts,jtf
+           DO mosaic_i=1,NLCAT
+              LANDUSEF2(i,mosaic_i,j)=LANDUSEF(i,mosaic_i,j)
+              mosaic_cat_index(i,mosaic_i,j)=mosaic_i
+           ENDDO
+        ENDDO
+     ENDDO
+
+     DO i = its,itf
+        DO j = jts,jtf
+          
+          NumPairs=NLCAT-1
+          
+          DO 
+               IF (NumPairs == 0) EXIT
+                   LastSwap = 1
+          DO  mosaic_i=1, NumPairs
+            IF(LANDUSEF2(i,mosaic_i, j) < LANDUSEF2(i,mosaic_i+1, j)  ) THEN
+               Temp = LANDUSEF2(i,mosaic_i, j)
+               LANDUSEF2(i,mosaic_i, j)=LANDUSEF2(i,mosaic_i+1, j)
+               LANDUSEF2(i,mosaic_i+1, j)=Temp            
+               LastSwap = mosaic_i 
+            
+               Temp2 =  mosaic_cat_index(i,mosaic_i,j)
+               mosaic_cat_index(i,mosaic_i,j)=mosaic_cat_index(i,mosaic_i+1,j)
+               mosaic_cat_index(i,mosaic_i+1,j)=Temp2
+            ENDIF
+          ENDDO
+               NumPairs = LastSwap - 1
+          ENDDO
+          
+        ENDDO
+      ENDDO
+
+  !===========================================================================   
+  ! For non-seaice grids, eliminate the seaice-tiles
+  !=========================================================================== 
+
+     DO i = its,itf
+        DO j = jts,jtf
+        
+         IF   (XLAND(I,J).LT.1.5)  THEN
+
+             ICE = 0
+                 IF( XICE(I,J).GE. XICE_THRESHOLD ) THEN
+                   WRITE (message_text,fmt='(a,2I5)') 'sea-ice at point, I and J = ', i,j
+                   CALL wrf_message(message_text)
+                 ICE = 1
+                 ENDIF   
+           
+          IF (ICE == 1)   Then         ! sea-ice case , eliminate sea-ice if they are not the dominant ones
+
+          IF (IVGTYP(i,j) == isice)  THEN    ! if this grid cell is dominanted by ice, then do nothing
+
+          ELSE
+
+                DO mosaic_i=2,mosaic_cat
+                   IF (mosaic_cat_index(i,mosaic_i,j) == isice ) THEN
+                       Temp4=LANDUSEF2(i,mosaic_i,j)
+                       Temp5=mosaic_cat_index(i,mosaic_i,j)
+
+                       LANDUSEF2(i,mosaic_i:NLCAT-1,j)=LANDUSEF2(i,mosaic_i+1:NLCAT,j)                       
+                       mosaic_cat_index(i,mosaic_i:NLCAT-1,j)=mosaic_cat_index(i,mosaic_i+1:NLCAT,j)
+
+                       LANDUSEF2(i,NLCAT,j)=Temp4
+                       mosaic_cat_index(i,NLCAT,j)=Temp5
+                   ENDIF 
+                 ENDDO
+
+          ENDIF   ! for (IVGTYP(i,j) == isice )
+          
+          ELSEIF (ICE ==0)  THEN
+          
+          IF ((mosaic_cat_index(I,1,J) .EQ. ISWATER)) THEN    
+          
+          ! xland < 1.5 but the dominant land use category based on our calculation is water
+	             
+           IF (IVGTYP(i,j) .EQ. ISWATER) THEN  
+           
+           ! xland < 1.5 but the dominant land use category based on the geogrid calculation is water, this must be wrong
+           
+              CALL wrf_message("IN MOSAIC_INIT")
+              WRITE(message_text,fmt='(a,3I6,2F8.2)') 'I,J,IVGTYP,XLAND,XICE = ',I,J,IVGTYP(I,J),xland(i,j),xice(i,j) 
+              CALL wrf_message(message_text)
+              CALL wrf_message("xland < 1.5 but the dominant land use category based on our calculation is water."//&
+                   "In addition, the dominant land use category based on the geogrid calculation is water, this must be wrong")
+           
+           ENDIF  ! for (IVGTYP(i,j) .EQ. ISWATER)
+           
+           IF (IVGTYP(i,j) .NE. ISWATER) THEN 
+           
+           ! xland < 1.5,   the dominant land use category based on our calculation is water, but based on the geogrid calculation is not water, which might be due to the inconsistence between land use data and land-sea mask
+           
+	       Temp4=LANDUSEF2(i,1,j)
+	       Temp5=mosaic_cat_index(i,1,j)
+	  
+	       LANDUSEF2(i,1:NLCAT-1,j)=LANDUSEF2(i,2:NLCAT,j)                       
+	       mosaic_cat_index(i,1:NLCAT-1,j)=mosaic_cat_index(i,2:NLCAT,j)
+	  
+	       LANDUSEF2(i,NLCAT,j)=Temp4
+	       mosaic_cat_index(i,NLCAT,j)=Temp5
+	             
+              CALL wrf_message("IN MOSAIC_INIT")
+              WRITE(message_text,fmt='(a,3I6,2F8.2)') 'I,J,IVGTYP,XLAND,XICE = ',I,J,IVGTYP(I,J),xland(i,j),xice(i,j) 
+              CALL wrf_message(message_text)
+              CALL wrf_message("xland < 1.5 but the dominant land use category based on our calculation is water."//&
+                   "this is fine as long as we change our calculation so that the dominant land use category is"//&
+                   "stwiched back to not water.")
+              WRITE(message_text,fmt='(a,2I6)') 'land use category has been switched, before and after values are ', &
+                   temp5,mosaic_cat_index(i,1,j)
+              CALL wrf_message(message_text)
+              WRITE(message_text,fmt='(a,2I6)') 'new dominant and second dominant cat are ', mosaic_cat_index(i,1,j),mosaic_cat_index(i,2,j)
+              CALL wrf_message(message_text)
+	             
+           ENDIF  ! for (IVGTYP(i,j) .NE. ISWATER)
+          
+           ELSE    !  for (mosaic_cat_index(I,1,J) .EQ. ISWATER)
+           
+                     DO mosaic_i=2,mosaic_cat
+	                IF (mosaic_cat_index(i,mosaic_i,j) == iswater ) THEN
+	                   Temp4=LANDUSEF2(i,mosaic_i,j)
+	                   Temp5=mosaic_cat_index(i,mosaic_i,j)
+	   
+	                   LANDUSEF2(i,mosaic_i:NLCAT-1,j)=LANDUSEF2(i,mosaic_i+1:NLCAT,j)                       
+	                   mosaic_cat_index(i,mosaic_i:NLCAT-1,j)=mosaic_cat_index(i,mosaic_i+1:NLCAT,j)
+	  
+	                   LANDUSEF2(i,NLCAT,j)=Temp4
+	                   mosaic_cat_index(i,NLCAT,j)=Temp5
+	                ENDIF 
+	              ENDDO
+             
+           ENDIF !  for (mosaic_cat_index(I,1,J) .EQ. ISWATER)
+             
+          ENDIF  !  for ICE == 1
+          
+      ELSE  ! FOR (XLAND(I,J).LT.1.5)
+      
+                 ICE = 0
+      
+                     IF( XICE(I,J).GE. XICE_THRESHOLD ) THEN
+                       WRITE (message_text,fmt='(a,2I6)') 'sea-ice at water point, I and J = ', i,j
+                       CALL wrf_message(message_text)
+                       ICE = 1
+                     ENDIF  
+      
+           IF ((mosaic_cat_index(I,1,J) .NE. ISWATER)) THEN    
+                
+                ! xland > 1.5 and the dominant land use category based on our calculation is not water
+      	             
+                 IF (IVGTYP(i,j) .NE. ISWATER) THEN  
+                 
+                 ! xland > 1.5 but the dominant land use category based on the geogrid calculation is not water, this must be wrong
+                 CALL wrf_message("IN MOSAIC_INIT")
+                 WRITE(message_text,fmt='(a,3I6,2F8.2)') 'I,J,IVGTYP,XLAND,XICE = ',I,J,IVGTYP(I,J),xland(i,j),xice(i,j)
+                 CALL wrf_message(message_text)
+                 CALL wrf_message("xland > 1.5 but the dominant land use category based on our calculation is not water."// &
+                      "in addition, the dominant land use category based on the geogrid calculation is not water,"//  &
+                      "this must be wrong.")
+                 ENDIF  ! for (IVGTYP(i,j) .NE. ISWATER)
+                 
+                 IF (IVGTYP(i,j) .EQ. ISWATER) THEN 
+                 
+                 ! xland > 1.5,   the dominant land use category based on our calculation is not water, but based on the geogrid calculation is water, which might be due to the inconsistence between land use data and land-sea mask
+
+                 CALL wrf_message("IN MOSAIC_INIT")
+                 WRITE(message_text,fmt='(a,3I6,2F8.2)') 'I,J,IVGTYP,XLAND,XICE = ',I,J,IVGTYP(I,J),xland(i,j),xice(i,j)
+                 CALL wrf_message(message_text)
+                 CALL wrf_message("xland > 1.5 but the dominant land use category based on our calculation is not water."// &
+                      "however, the dominant land use category based on the geogrid calculation is water")
+                 CALL wrf_message("This is fine. We do not need to do anyting because in the noaddrv, "//&
+                      "we use xland as a criterion for whether using"// &
+                      "mosaic or not when xland > 1.5, no mosaic will be used anyway")
+      	             
+                 ENDIF  ! for (IVGTYP(i,j) .NE. ISWATER)
+                
+           ENDIF !  for (mosaic_cat_index(I,1,J) .NE. ISWATER)
+      
+        ENDIF  ! FOR (XLAND(I,J).LT.1.5)
+
+          ENDDO
+      ENDDO
+      
+  !===========================================================================   
+  ! normalize
+  !=========================================================================== 
+
+     DO i = its,itf
+        DO j = jts,jtf
+
+          Temp6=0
+
+            DO mosaic_i=1,mosaic_cat
+               Temp6=Temp6+LANDUSEF2(i,mosaic_i,j)
+            ENDDO
+            
+            if (Temp6 .LT. 1e-5)  then
+            
+            Temp6 = 1e-5
+            WRITE (message_text,fmt='(a,e8.1)') 'the total land surface fraction is less than ', temp6
+            CALL wrf_message(message_text)
+            WRITE (message_text,fmt='(a,2I6,4F8.2)') 'some landusef values at i,j are ', &
+                 i,j,landusef2(i,1,j),landusef2(i,2,j),landusef2(i,3,j),landusef2(i,4,j)
+            CALL wrf_message(message_text)
+            WRITE (message_text,fmt='(a,2I6,3I6)') 'some mosaic cat values at i,j are ', &
+                 i,j,mosaic_cat_index(i,1,j),mosaic_cat_index(i,2,j),mosaic_cat_index(i,3,j) 
+            CALL wrf_message(message_text)
+            
+            endif
+
+            LANDUSEF2(i,1:mosaic_cat, j)=LANDUSEF2(i,1:mosaic_cat,j)*(1/Temp6)
+
+          ENDDO
+      ENDDO
+      
+  !===========================================================================   
+  ! initilize the variables
+  !===========================================================================   
+
+     DO i = its,itf
+        DO j = jts,jtf
+    
+             DO mosaic_i=1,mosaic_cat
+        
+            TSK_mosaic(i,mosaic_i,j)=TSK(i,j)          
+            CANWAT_mosaic(i,mosaic_i,j)=CANWAT(i,j) 
+            SNOW_mosaic(i,mosaic_i,j)=SNOW(i,j) 
+            SNOWH_mosaic(i,mosaic_i,j)=SNOWH(i,j)  
+            SNOWC_mosaic(i,mosaic_i,j)=SNOWC(i,j) 
+
+            ALBEDO_mosaic(i,mosaic_i,j)=ALBEDO(i,j)
+            ALBBCK_mosaic(i,mosaic_i,j)=ALBBCK(i,j)
+            EMISS_mosaic(i,mosaic_i,j)=EMISS(i,j) 
+            EMBCK_mosaic(i,mosaic_i,j)=EMBCK(i,j) 
+            ZNT_mosaic(i,mosaic_i,j)=Z0(i,j)
+            Z0_mosaic(i,mosaic_i,j)=Z0(i,j)              
+  
+              DO soil_k=1,num_soil_layers 
+  
+            TSLB_mosaic(i,num_soil_layers*(mosaic_i-1)+soil_k,j)=TSLB(i,soil_k,j)
+            SMOIS_mosaic(i,num_soil_layers*(mosaic_i-1)+soil_k,j)=SMOIS(i,soil_k,j)
+            SH2O_mosaic(i,num_soil_layers*(mosaic_i-1)+soil_k,j)=SH2O(i,soil_k,j)  
+          
+              ENDDO
+           
+           TR_URB2D_mosaic(i,mosaic_i,j)=TSK(i,j)   
+           TB_URB2D_mosaic(i,mosaic_i,j)=TSK(i,j)   
+           TG_URB2D_mosaic(i,mosaic_i,j)=TSK(i,j)   
+           TC_URB2D_mosaic(i,mosaic_i,j)=TSK(i,j)   
+           TS_URB2D_mosaic(i,mosaic_i,j)=TSK(i,j)   
+           TS_RUL2D_mosaic(i,mosaic_i,j)=TSK(i,j)   
+           QC_URB2D_mosaic(i,mosaic_i,j)=0.01
+           SH_URB2D_mosaic(i,mosaic_i,j)=0
+           LH_URB2D_mosaic(i,mosaic_i,j)=0
+           G_URB2D_mosaic(i,mosaic_i,j)=0
+           RN_URB2D_mosaic(i,mosaic_i,j)=0
+          
+          TRL_URB3D_mosaic(I,4*(mosaic_i-1)+1,J)=TSLB(I,1,J)+0.
+          TRL_URB3D_mosaic(I,4*(mosaic_i-1)+2,J)=0.5*(TSLB(I,1,J)+TSLB(I,2,J))
+          TRL_URB3D_mosaic(I,4*(mosaic_i-1)+3,J)=TSLB(I,2,J)+0.
+          TRL_URB3D_mosaic(I,4*(mosaic_i-1)+4,J)=TSLB(I,2,J)+(TSLB(I,3,J)-TSLB(I,2,J))*0.29
+
+          TBL_URB3D_mosaic(I,4*(mosaic_i-1)+1,J)=TSLB(I,1,J)+0.
+          TBL_URB3D_mosaic(I,4*(mosaic_i-1)+2,J)=0.5*(TSLB(I,1,J)+TSLB(I,2,J))
+          TBL_URB3D_mosaic(I,4*(mosaic_i-1)+3,J)=TSLB(I,2,J)+0.
+          TBL_URB3D_mosaic(I,4*(mosaic_i-1)+4,J)=TSLB(I,2,J)+(TSLB(I,3,J)-TSLB(I,2,J))*0.29           
+                    
+          TGL_URB3D_mosaic(I,4*(mosaic_i-1)+1,J)=TSLB(I,1,J)
+          TGL_URB3D_mosaic(I,4*(mosaic_i-1)+2,J)=TSLB(I,2,J)
+          TGL_URB3D_mosaic(I,4*(mosaic_i-1)+3,J)=TSLB(I,3,J)
+          TGL_URB3D_mosaic(I,4*(mosaic_i-1)+4,J)=TSLB(I,4,J)
+           
+            ENDDO
+          ENDDO
+      ENDDO
+
+   ! simple test
+   
+       DO i = its,itf
+        DO j = jts,jtf 
+   
+           IF ((xland(i,j).LT. 1.5 ) .AND. (mosaic_cat_index(I,1,J) .EQ. ISWATER)) THEN
+             CALL wrf_message("After MOSAIC_INIT")
+             WRITE (message_text,fmt='(a,2I6,2F8.2,2I6)') 'weird xland,xice,mosaic_cat_index and ivgtyp at I,J = ', &
+                i,j,xland(i,j),xice(i,j),mosaic_cat_index(I,1,J),IVGTYP(i,j)
+             CALL wrf_message(message_text)
+           ENDIF
+           
+        ENDDO
+      ENDDO
+      
+ ENDIF      !  for not restart
+      
+!--------------------------------      
+  END SUBROUTINE lsm_mosaic_init  
+!--------------------------------  
+#endif
 END MODULE module_sf_noahdrv


### PR DESCRIPTION
This pull request demonstrates implementation of an optional mosaic/tiling (or simply the "mosaic") approach (based on Li et al., 2013) in the MPAS-Noah land surface model to assess the impact of subgrid-scale variability in land cover composition. Currently, the default land cover composition in MPAS-Noah is only based on a "dominant" approach, as each grid cell is assumed to be entirely composed of the most abundant tile. In this new mosaic approach, a certain number of tiles (set as N by the user), each representing a land cover category, is considered within each grid cell (Li et al., 2013).     Stark differences between model predicted ground heat flux, sensible heat flux, surface temperature, 2-m temperature, and 2-m specific humidity are apparent between the Noah mosaic and dominant approaches.   Li et al. (2013) also demonstrated an improved performance for the mosaic compared to the dominant approach in regional WRF simulations, and that results with the mosaic approach are less sensitive to the spatial resolution of the grid.    

The motivation for implementation of the mosaic is that sub-grid scale representation of land cover is vital at coarse model resolutions typically applied at the global scale.  Sub-grid scale land cover may also be further important to the gradually refining mesh (i.e., variable spatial resolution) inherent to MPAS. 

The implementation of the mosaic approach requires the "real world" fractional land use variable (i.e., landusef) as input.  In this implementation, I use the NLCD40 land cover data based landusef. 

The mosaic approach has been implemented here as an optional setting, where the user sets the following atmosphere.namelist options:
 config_landuse_data      = NLCD40
 num_land_cat             = 40
 config_surface_mosaic = true
 config_mosaic_cat          = 8

The user sets config_surface_mosaic = true to turn on the Noah mosaic option, and then sets config_mosaic_cat  to control the number (N) of mosaic tiles (max = num_land_cat) considered within each grid cell.   

In addition, optional Noah mosaic variables may be included in the output by via an additional stream name "mosaic" in the stream_list.atmosphere, where user defined variables are set in the stream_list.atmosphere.output.mosaic file.
<stream name="mosaic"
        type="output"
        filename_template="mosaic.$Y-$M-$D.nc"
        filename_interval="1_00:00:00"
        precision="single"
        clobber_mode="overwrite"
        output_interval="1:00:00">
        <file name="stream_list.atmosphere.output.mosaic"/>
</stream>

For this implementation, the NLCD40 land use parameters must also be added to the Noah table (i.e., LANDUSE.TBL) for the summer and winter.  An example of the updated LANDUSE.TBL is attached here.

[LANDUSE.TBL.txt](https://github.com/MPAS-Dev/MPAS-Release/files/1229593/LANDUSE.TBL.txt)

Comparative results and model performance of a test simulation for July 2013 over a quasi-uniform 92_25 mesh, will be provided in the additional comments of this pull request.  Of course the performance of the Noah mosaic is tied to the level of detail of the input land cover data set.  

Patrick

Citation: Li, D., E. Bou-Zeid, M. Barlage, F. Chen, and J. A. Smith (2013), Development and evaluation of a mosaic approach in the WRF-Noah framework, J. Geophys. Res. Atmos., 118, 11,918–11,935, doi:10.1002/2013JD020657.
